### PR TITLE
Fix --skip-lgtm option was never passed to the `#deliver` method

### DIFF
--- a/lib/git_reflow/commands/deliver.rb
+++ b/lib/git_reflow/commands/deliver.rb
@@ -7,7 +7,7 @@ command :deliver do |c|
   c.desc 'merge your feature branch down to your base branch, and cleanup your feature branch'
   c.arg_name 'base_branch - the branch you want to merge into'
   c.action do |global_options,options,args|
-    deliver_options = {'base' => nil, 'head' => nil}
+    deliver_options = {'base' => nil, 'head' => nil, 'skip_lgtm' => options[:'skip-lgtm']}
     case args.length
     when 2
       deliver_options['base'] = args[0]
@@ -15,7 +15,6 @@ command :deliver do |c|
     when 1
       deliver_options['base'] = args[0]
     end
-    deliver_options.merge({'skip_lgtm' => options[:'skip-lgtm']})
     GitReflow.deliver deliver_options
   end
 end


### PR DESCRIPTION
`Hash#merge` returns a new Hash, but the modified hash was not used
anywhere.
