### PR TITLE
Fixes issue setting up git reflow on Ruby 2.0/mavericks and duplicate lines in merge message

### DIFF
--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -120,9 +120,7 @@ module GitReflow
         # if there any comment_authors left, then they haven't given a lgtm after the last commit
         if (has_comments and open_comment_authors.empty?) or options['skip_lgtm']
           lgtm_authors   = comment_authors_for_pull_request(existing_pull_request, :with => LGTM)
-          commit_message = "#{existing_pull_request[:title]}\n#{(existing_pull_request[:body] || get_first_commit_message)}"
-          puts commit_message
-          exit
+          commit_message = "#{(existing_pull_request[:body] || get_first_commit_message)}"
           puts "Merging pull request ##{existing_pull_request.number}: '#{existing_pull_request.title}', from '#{existing_pull_request.head.label}' into '#{existing_pull_request.base.label}'"
 
           update_destination(options['base'])


### PR DESCRIPTION
Fixes issue setting up git reflow on Ruby 2.0/mavericks and duplicate lines in merge message:

[fix] Status command doesn't open url of pull request (#48)
[fix] Deliver merge commit message has duplicate lines (#49)
