### PR TITLE
Add note to created oauth token so users can find them on their tokens page

### DIFF
--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -45,7 +45,7 @@ module GitReflow
         config.ssl         = {:verify => false}
       end
 
-      authorization = github.oauth.create 'scopes' => ['repo'], 'note' => 'git-reflow'
+      authorization = github.oauth.create 'scopes' => ['repo'], 'note' => "git-reflow (#{`hostname`.strip})"
       oauth_token   = authorization[:token]
 
       if project_only


### PR DESCRIPTION
Without this, tokens are listed like this:

![authorized_applications](https://f.cloud.github.com/assets/277/1571261/5ac82090-5100-11e3-88ca-a396e897a2f8.png)

On this page: https://github.com/settings/applications.
