### PR TITLE
Store Github OAuth token in a seperate file, but refer to that file from the git config

### DIFF
--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -195,11 +195,12 @@ module GitReflow
   end
 
   def github_oauth_token
-   github_oauth_token_file = `git config --get github.oauth-token-file`.strip
+    github_oauth_token = `git config --get github.oauth-token`.strip
 
-   if github_oauth_token_file.empty?
-      `git config --get github.oauth-token`.strip
+    if not github_oauth_token.empty?
+      github_oauth_token
     else
+      github_oauth_token_file = `git config --get github.oauth-token-file`.strip
       File.read(File.expand_path(github_oauth_token_file, ENV["HOME"])).strip
     end
   end

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -193,7 +193,13 @@ module GitReflow
   end
 
   def github_oauth_token
-    `git config --get github.oauth-token`.strip
+   github_oauth_token_file = `git config --get github.oauth-token-file`.strip
+
+   if github_oauth_token_file.empty?
+      `git config --get github.oauth-token`.strip
+    else
+      File.read(File.expand_path(github_oauth_token_file, ENV["HOME"])).strip
+    end
   end
 
   def current_branch

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -48,12 +48,10 @@ module GitReflow
       authorization = github.oauth.create 'scopes' => ['repo']
       oauth_token   = authorization[:token]
 
-      oauth_token_file = ask("Please enter where the OAuth token should be stored: ") { |q| q.default = File.expand_path("~/.github-oauth-token") }
-
       if project_only
-        set_oauth_token(oauth_token, oauth_token_file, local: true)
+        set_oauth_token(oauth_token, options[:github_oauth_token_file], local: true)
       else
-        set_oauth_token(oauth_token, oauth_token_file)
+        set_oauth_token(oauth_token, options[:github_oauth_token_file])
       end
     rescue StandardError => e
       puts "\nInvalid username or password"
@@ -228,11 +226,10 @@ module GitReflow
   end
 
   def set_oauth_token(oauth_token, oauth_token_file, options = {})
-    File.open(oauth_token_file, 'w') { |f| f.write(oauth_token) }
-
     if options.delete(:local)
-      `git config --replace-all github.oauth-token-file #{oauth_token_file}`
+      `git config --replace-all github.oauth-token #{oauth_token}`
     else
+      File.open(oauth_token_file, 'w') { |f| f.write(oauth_token) }
       `git config --global --replace-all github.oauth-token-file #{oauth_token_file}`
     end
   end

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -48,10 +48,12 @@ module GitReflow
       authorization = github.oauth.create 'scopes' => ['repo']
       oauth_token   = authorization[:token]
 
+      oauth_token_file = ask("Please enter where the OAuth token should be stored: ") { |q| q.default = File.expand_path("~/.github-oauth-token") }
+
       if project_only
-        set_oauth_token(oauth_token, local: true)
+        set_oauth_token(oauth_token, oauth_token_file, local: true)
       else
-        set_oauth_token(oauth_token)
+        set_oauth_token(oauth_token, oauth_token_file)
       end
     rescue StandardError => e
       puts "\nInvalid username or password"
@@ -224,11 +226,13 @@ module GitReflow
     `git log --pretty=format:"%s" --no-merges -n 1`.strip
   end
 
-  def set_oauth_token(oauth_token, options = {})
+  def set_oauth_token(oauth_token, oauth_token_file, options = {})
+    File.open(oauth_token_file, 'w') { |f| f.write(oauth_token) }
+
     if options.delete(:local)
-      `git config --replace-all github.oauth-token #{oauth_token}`
+      `git config --replace-all github.oauth-token-file #{oauth_token_file}`
     else
-      `git config --global --replace-all github.oauth-token #{oauth_token}`
+      `git config --global --replace-all github.oauth-token-file #{oauth_token_file}`
     end
   end
 

--- a/lib/git_reflow/commands/setup.rb
+++ b/lib/git_reflow/commands/setup.rb
@@ -3,7 +3,9 @@ command :setup do |c|
   c.desc 'sets up your api token with GitHub'
   c.switch [:l, :local], default_value: false, desc: 'setup GitReflow for the current project only'
   c.switch [:e, :enterprise], default_value: false, desc: 'setup GitReflow with a Github Enterprise account'
+  c.flag [:"github-oauth-token-file"], default_value: File.join(ENV['HOME'], '.github-oauth-token'), desc: 'the file in which the Github OAuth token will be stored'
+
   c.action do |global_options, options, args|
-    GitReflow.setup({ project_only: options[:local], enterprise: options[:enterprise] })
+    GitReflow.setup({ project_only: options[:local], enterprise: options[:enterprise], github_oauth_token_file: options[:"github-oauth-token-file"] })
   end
 end


### PR DESCRIPTION
This solves issue #54. This makes it possible for people to keep their `.gitconfig` under version control and share it publicly without having to take care never to leak the access token. 

For now, backwards compatibility with the old config key is maintained: if an OAuth token is set directly, this is used, otherwise it is read from a file. New `git reflow setup` invocations set up the new file-based config.