### PR TITLE
Make sure to create feature branch with current branch as base

### DIFF
--- a/lib/git_reflow/commands/start.rb
+++ b/lib/git_reflow/commands/start.rb
@@ -2,7 +2,7 @@ desc 'Start will create a new feature branch and setup remote tracking'
 long_desc <<LONGTIME
   Performs the following:\n
   \t$ git pull origin <current_branch>\n
-  \t$ git push origin master:refs/heads/[new_feature_branch]\n
+  \t$ git push origin <current_branch>:refs/heads/[new_feature_branch]\n
   \t$ git checkout --track -b [new_feature_branch] origin/[new_feature_branch]\n
 LONGTIME
 arg_name '[new-feature-branch-name] - name of the new feature branch'


### PR DESCRIPTION
When calling `git reflow start some_branch` the new branch is always based on the master branch instead of the current branch.
