### PR TITLE
tmp_squash_msh is not removed if we use git reflow in other directories than root.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_reflow (0.5.2)
+    git_reflow (0.5.3)
       colorize (= 0.6.0)
       github_api (= 0.12.3)
       gli (= 2.12.2)

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -58,8 +58,9 @@ module GitReflow
     end
 
     def append_to_squashed_commit_message(message = '')
-      run "echo \"#{message}\" | cat - .git/SQUASH_MSG > ./tmp_squash_msg"
-      run 'mv ./tmp_squash_msg .git/SQUASH_MSG'
+      git_root_dir = run('git rev-parse --show-toplevel').strip
+      run "echo \"#{message}\" | cat - #{git_root_dir}/.git/SQUASH_MSG > #{git_root_dir}/tmp_squash_msg"
+      run "mv #{git_root_dir}/tmp_squash_msg #{git_root_dir}/.git/SQUASH_MSG"
     end
     
     private

--- a/lib/git_reflow/sandbox.rb
+++ b/lib/git_reflow/sandbox.rb
@@ -15,7 +15,9 @@ module GitReflow
       if options[:with_system] == true
         system(command)
       elsif options[:loud] == true
-        puts `#{command}`
+        output = `#{command}`
+        puts output
+        output
       else
         `#{command}`
       end

--- a/lib/git_reflow/version.rb
+++ b/lib/git_reflow/version.rb
@@ -1,3 +1,3 @@
 module GitReflow
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -145,11 +145,14 @@ describe GitReflow::GitHelpers do
 
   describe ".append_to_squashed_commit_message(message)" do
     let(:message) { "do do the voodoo that you do" }
+    let(:root_dir) { `pwd`.strip }
     subject { Gitacular.append_to_squashed_commit_message(message) }
     it "appends the message to git's SQUASH_MSG temp file" do
-      expect{ subject }.to have_run_commands_in_order [
-        "echo \"#{message}\" | cat - .git/SQUASH_MSG > ./tmp_squash_msg",
-        'mv ./tmp_squash_msg .git/SQUASH_MSG'
+      stub_command("git rev-parse --show-toplevel", "#{root_dir}\n")
+      expect { subject }.to have_run_commands_in_order [
+        "git rev-parse --show-toplevel",
+        "echo \"#{message}\" | cat - #{root_dir}/.git/SQUASH_MSG > #{root_dir}/tmp_squash_msg",
+        "mv #{root_dir}/tmp_squash_msg #{root_dir}/.git/SQUASH_MSG"
       ]
     end
   end

--- a/spec/support/command_line_helpers.rb
+++ b/spec/support/command_line_helpers.rb
@@ -1,8 +1,9 @@
 module CommandLineHelpers
   def stub_command_line
-    $commands_ran = []
-    $output       = []
-    $says         = []
+    $commands_ran     = []
+    $stubbed_commands = {}
+    $output           = []
+    $says             = []
 
     stub_run_for GitReflow
     stub_run_for GitReflow::Sandbox
@@ -17,7 +18,9 @@ module CommandLineHelpers
     module_to_stub.stub(:run) do |command, options|
       options ||= {}
       $commands_ran << Hashie::Mash.new(command: command, options: options)
+      ret_value = $stubbed_commands[command] || ""
       command = "" # we need this due to a bug in rspec that will keep this assignment on subsequent runs of the stub
+      ret_value
     end
     module_to_stub.stub(:say) do |output, type|
       $says << {message: output, type: type}
@@ -26,9 +29,11 @@ module CommandLineHelpers
 
   def reset_stubbed_command_line
     $commands_ran = []
+    $stubbed_commands = {}
   end
 
   def stub_command(command, return_value)
+    $stubbed_commands[command] = return_value
     GitReflow::Sandbox.stub(:run).with(command).and_return(return_value)
   end
 end


### PR DESCRIPTION
We add the Git root directory to prevent the problem. This fixes #97