### PR TITLE
Add number attribute to Base:PullRequest

### DIFF
--- a/lib/git_reflow/git_server/base.rb
+++ b/lib/git_reflow/git_server/base.rb
@@ -7,7 +7,7 @@ module GitReflow
     @@connection = nil
 
     class PullRequest
-      attr_accessor :description, :html_url, :feature_branch_name, :base_branch_name, :build_status, :source_object
+      attr_accessor :description, :html_url, :feature_branch_name, :base_branch_name, :build_status, :source_object, :number
 
       def initialize(attributes)
         raise "PullRequest#initialize must be implemented"

--- a/lib/git_reflow/git_server/bit_bucket.rb
+++ b/lib/git_reflow/git_server/bit_bucket.rb
@@ -7,7 +7,7 @@ module GitReflow
 
       class PullRequest < Base::PullRequest
         def initialize(attributes)
-          self.description = attributes.description
+          self.description         = attributes.description
           self.source_object       = attributes
           self.number              = attributes.id
           self.html_url            = "#{attributes.source.repository.links.html.href}/pull-request/#{self.number}"


### PR DESCRIPTION
Otherwise, we would get this error:

```
Error: #<NoMethodError: undefined method `number=' for #<GitReflow::GitServer::BitBucket::PullRequest:0x007f8ab5dd1688>>
```

I was trying to write a test for this, but it seems to be a very big task because a function like `stub_github_with` is needed for bitbucket.