### PR TITLE
User configuration for always pushing and cleaning up branches.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -310,6 +310,14 @@ http://reenhanced.com/images/reflow.png
   Squash commits to master mean every commit represents the whole feature, not a "typo fix".
 
 
+== Configuration
+
+  In order to streamline delivery you can set the following git config to
+  always push the branch after merge and clean up the feature branch.
+
+  git config --global --add "reflow.always-deploy-and-cleanup" "true"
+
+
 ---
 
 == Contributing

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -99,8 +99,12 @@ module GitReflow
 
           if committed
             say "Merge complete!", :success
-            deploy_and_cleanup = ask "Would you like to push this branch to your remote repo and cleanup your feature branch? "
-            if deploy_and_cleanup =~ /^y/i
+
+            # check if user always wants to push and cleanup, otherwise ask
+            always_deploy_and_cleanup = GitReflow::Config.get('reflow.always-deploy-and-cleanup') == "true"
+            deploy_and_cleanup = always_deploy_and_cleanup || (ask "Would you like to push this branch to your remote repo and cleanup your feature branch? ") =~ /^y/i
+
+            if deploy_and_cleanup
               run_command_with_label "git push origin #{options['base']}"
               run_command_with_label "git push origin :#{feature_branch}"
               run_command_with_label "git branch -D #{feature_branch}"

--- a/spec/git_reflow_spec.rb
+++ b/spec/git_reflow_spec.rb
@@ -281,17 +281,42 @@ describe GitReflow do
                 end
               end
 
-              it "pushes local squash merged base branch to remote repo" do
-                expect { subject }.to have_run_command("git push origin master")
+              context "not always" do
+                before do
+                  GitReflow::Config.stub(:get) { "false" }
+                end
+
+                it "pushes local squash merged base branch to remote repo" do
+                  expect { subject }.to have_run_command("git push origin master")
+                end
+
+                it "deletes the remote feature branch" do
+                  expect { subject }.to have_run_command("git push origin :new-feature")
+                end
+
+                it "deletes the local feature branch" do
+                  expect { subject }.to have_run_command("git branch -D new-feature")
+                end
               end
 
-              it "deletes the remote feature branch" do
-                expect { subject }.to have_run_command("git push origin :new-feature")
+              context "always" do
+                before do
+                  GitReflow::Config.stub(:get) { "true" }
+                end
+
+                it "pushes local squash merged base branch to remote repo" do
+                  expect { subject }.to have_run_command("git push origin master")
+                end
+
+                it "deletes the remote feature branch" do
+                  expect { subject }.to have_run_command("git push origin :new-feature")
+                end
+
+                it "deletes the local feature branch" do
+                  expect { subject }.to have_run_command("git branch -D new-feature")
+                end
               end
 
-              it "deletes the local feature branch" do
-                expect { subject }.to have_run_command("git branch -D new-feature")
-              end
             end
 
             context "and not cleaning up feature branch" do


### PR DESCRIPTION
Streamlines the deliver command a bit.

This is a continuation of https://github.com/reenhanced/gitreflow/pull/130
I fidgeted around with the branches/repo a bit unfortunately and lost that history.