### PR TITLE
Fix review message parsing from editor failed

### DIFF
--- a/lib/git_reflow/commands/review.rb
+++ b/lib/git_reflow/commands/review.rb
@@ -26,7 +26,7 @@ command :review do |c|
 
       GitReflow.run("#{default_editor} #{pull_request_msg_file}", with_system: true)
 
-      pr_msg = File.open(pull_request_msg_file).each_line.map(&:strip).to_a
+      pr_msg = File.read(pull_request_msg_file).split(/[\r\n]|\r\n/).map(&:strip)
       title  = pr_msg.shift
 
       File.delete(pull_request_msg_file)


### PR DESCRIPTION
In the editor, when I wrote out

```
a

b
```

the pull request's title only "b", and there was no body:

```
Review your PR:
--------
Title:
b

Body:

--------
Submit pull request? (Y)
```

With this change, I get the expected title and body:

```
Review your PR:
--------
Title:
a

Body:
b
--------
Submit pull request? (Y)
```