### PR TITLE
[54] Setup special Reflow config file and include it in setup command

### DIFF
--- a/lib/git_reflow/commands/setup.rb
+++ b/lib/git_reflow/commands/setup.rb
@@ -4,12 +4,13 @@ command :setup do |c|
   c.switch [:l, :local], default_value: false, desc: 'setup GitReflow for the current project only'
   c.switch [:e, :enterprise], default_value: false, desc: 'setup GitReflow with a Github Enterprise account'
   c.action do |global_options, options, args|
-    reflow_options = { project_only: options[:local], enterprise: options[:enterprise] }
+    reflow_options             = { project_only: options[:local], enterprise: options[:enterprise] }
+    existing_git_include_paths = GitReflow::Config.get('include.path', all: true).split("\n")
 
-    unless File.exist?(GitReflow::Config::CONFIG_FILE_PATH)
+    unless File.exist?(GitReflow::Config::CONFIG_FILE_PATH) or existing_git_include_paths.include?(GitReflow::Config::CONFIG_FILE_PATH)
       GitReflow.run "touch #{GitReflow::Config::CONFIG_FILE_PATH}"
       GitReflow.say "Created #{GitReflow::Config::CONFIG_FILE_PATH} for Reflow specific configurations", :notice
-      GitReflow::Config.add "include.path", GitReflow::Config::CONFIG_FILE_PATH
+      GitReflow::Config.add "include.path", GitReflow::Config::CONFIG_FILE_PATH, global: true
       GitReflow.say "Added #{GitReflow::Config::CONFIG_FILE_PATH} to ~/.gitconfig include paths", :notice
     end
 

--- a/lib/git_reflow/commands/setup.rb
+++ b/lib/git_reflow/commands/setup.rb
@@ -5,6 +5,14 @@ command :setup do |c|
   c.switch [:e, :enterprise], default_value: false, desc: 'setup GitReflow with a Github Enterprise account'
   c.action do |global_options, options, args|
     reflow_options = { project_only: options[:local], enterprise: options[:enterprise] }
+
+    unless File.exist?(GitReflow::Config::CONFIG_FILE_PATH)
+      GitReflow.run "touch #{GitReflow::Config::CONFIG_FILE_PATH}"
+      GitReflow.say "Created #{GitReflow::Config::CONFIG_FILE_PATH} for Reflow specific configurations", :notice
+      GitReflow::Config.add "include.path", GitReflow::Config::CONFIG_FILE_PATH
+      GitReflow.say "Added #{GitReflow::Config::CONFIG_FILE_PATH} to ~/.gitconfig include paths", :notice
+    end
+
     choose do |menu|
       menu.header = "Available remote Git Server services:"
       menu.prompt = "Which service would you like to use for this project?  "

--- a/lib/git_reflow/config.rb
+++ b/lib/git_reflow/config.rb
@@ -2,6 +2,8 @@ module GitReflow
   module Config
     extend self
 
+    CONFIG_FILE_PATH = "~/.gitconfig.reflow".freeze
+
     def get(key, reload: false, all: false, local: false)
       if reload == false and cached_key_value = instance_variable_get(:"@#{key.tr('.-', '_')}")
         cached_key_value
@@ -21,7 +23,7 @@ module GitReflow
       if local
         GitReflow::Sandbox.run "git config --replace-all #{key} \"#{value}\"", loud: false
       else
-        GitReflow::Sandbox.run "git config --global --replace-all #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --replace-all #{key} \"#{value}\"", loud: false
       end
     end
 
@@ -30,15 +32,17 @@ module GitReflow
       if local
         GitReflow::Sandbox.run "git config --unset-all #{key} #{value}", loud: false
       else
-        GitReflow::Sandbox.run "git config --global --unset-all #{key} #{value}", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --unset-all #{key} #{value}", loud: false
       end
     end
 
-    def add(key, value, local: false)
-      if local
+    def add(key, value, local: false, global: false)
+      if global
+        GitReflow::Sandbox.run "git config --global --add #{key} \"#{value}\"", loud: false
+      elsif local
         GitReflow::Sandbox.run "git config --add #{key} \"#{value}\"", loud: false
       else
-        GitReflow::Sandbox.run "git config --global --add #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --add #{key} \"#{value}\"", loud: false
       end
     end
   end

--- a/spec/lib/git_reflow/config_spec.rb
+++ b/spec/lib/git_reflow/config_spec.rb
@@ -16,7 +16,7 @@ describe GitReflow::Config do
     end
 
     context "and checking for updates" do
-      before  { GitReflow::Config.get('checknorris.roundhouse') }
+      before  { GitReflow::Config.get('chucknorris.roundhouse') }
       subject { GitReflow::Config.get('chucknorris.roundhouse') }
       it      { expect{ subject }.to_not have_run_command_silently 'git config --get chucknorris.roundhouse-kick' }
     end
@@ -29,7 +29,7 @@ describe GitReflow::Config do
 
   describe ".set(key)" do
     subject { GitReflow::Config.set('chucknorris.roundhouse', 'to the face') }
-    it      { expect{ subject }.to have_run_command_silently 'git config --global --replace-all chucknorris.roundhouse "to the face"' }
+    it      { expect{ subject }.to have_run_command_silently 'git config -f ~/.gitconfig.reflow --replace-all chucknorris.roundhouse "to the face"' }
 
     context "for current project only" do
       subject { GitReflow::Config.set('chucknorris.roundhouse', 'to the face', local: true) }
@@ -39,11 +39,11 @@ describe GitReflow::Config do
 
   describe ".unset(key)" do
     subject { GitReflow::Config.unset('chucknorris.roundhouse') }
-    it      { expect{ subject }.to have_run_command_silently 'git config --global --unset-all chucknorris.roundhouse ' }
+    it      { expect{ subject }.to have_run_command_silently 'git config -f ~/.gitconfig.reflow --unset-all chucknorris.roundhouse ' }
 
     context "for multi-value keys" do
       subject { GitReflow::Config.unset('chucknorris.roundhouse', value: 'to the face') }
-      it      { expect{ subject }.to have_run_command_silently 'git config --global --unset-all chucknorris.roundhouse "to the face"' }
+      it      { expect{ subject }.to have_run_command_silently 'git config -f ~/.gitconfig.reflow --unset-all chucknorris.roundhouse "to the face"' }
     end
 
     context "for current project only" do
@@ -59,11 +59,16 @@ describe GitReflow::Config do
 
   describe ".add(key)" do
     subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face') }
-    it      { expect{ subject }.to have_run_command_silently 'git config --global --add chucknorris.roundhouse "to the face"' }
+    it      { expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add chucknorris.roundhouse \"to the face\"" }
 
     context "for current project only" do
       subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face', local: true) }
       it      { expect{ subject }.to have_run_command_silently 'git config --add chucknorris.roundhouse "to the face"' }
+    end
+
+    context "globally" do
+      subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face', global: true) }
+      it      { expect{ subject }.to have_run_command_silently 'git config --global --add chucknorris.roundhouse "to the face"' }
     end
   end
 end

--- a/spec/lib/git_server/git_hub_spec.rb
+++ b/spec/lib/git_server/git_hub_spec.rb
@@ -103,10 +103,10 @@ describe GitReflow::GitServer::GitHub do
         end
 
         it "creates git config keys for github connections" do
-          expect{ subject }.to have_run_command_silently "git config --global --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
-          expect{ subject }.to have_run_command_silently "git config --global --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
-          expect{ subject }.to have_run_command_silently "git config --global --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-          expect{ subject }.to have_run_command_silently "git config --global --replace-all reflow.git-server \"GitHub\""
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
         end
 
         context "exclusive to project" do
@@ -118,16 +118,16 @@ describe GitReflow::GitServer::GitHub do
           end
 
           it "creates _local_ git config keys for github connections" do
-            expect{ subject }.to_not have_run_command_silently "git config --global --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
-            expect{ subject }.to_not have_run_command_silently "git config --global --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
-            expect{ subject }.to_not have_run_command_silently "git config --global --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-            expect{ subject }.to_not have_run_command_silently "git config --global --replace-all reflow.git-server \"GitHub\""
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
 
             expect{ subject }.to have_run_command_silently "git config --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
             expect{ subject }.to have_run_command_silently "git config --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
             expect{ subject }.to have_run_command_silently "git config --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
             expect{ subject }.to have_run_command_silently "git config --replace-all reflow.git-server \"GitHub\""
-            expect{ subject }.to have_run_command_silently "git config --global --add reflow.local-projects \"#{user}/#{repo}\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add reflow.local-projects \"#{user}/#{repo}\""
           end
         end
 
@@ -135,10 +135,10 @@ describe GitReflow::GitServer::GitHub do
           let(:github) { GitReflow::GitServer::GitHub.new(enterprise: true) }
           before { GitReflow::GitServer::GitHub.stub(:@using_enterprise).and_return(true) }
           it "creates git config keys for github connections" do
-            expect{ subject }.to have_run_command_silently "git config --global --replace-all github.site \"#{enterprise_site}\""
-            expect{ subject }.to have_run_command_silently "git config --global --replace-all github.endpoint \"#{enterprise_api}\""
-            expect{ subject }.to have_run_command_silently "git config --global --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-            expect{ subject }.to have_run_command_silently "git config --global --replace-all reflow.git-server \"GitHub\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{enterprise_site}\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{enterprise_api}\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
           end
         end
       end


### PR DESCRIPTION
* #54 - Create new ~/.gitconfig.reflow file and include it in global .gitconfig
* All git config settings now update and reference the new reflow specific config file

Fixes #54