### PR TITLE
Respect GitHub pull request template

### DIFF
--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -53,7 +53,7 @@ module GitReflow
           pull_request_msg_file = "#{GitReflow.git_root_dir}/.git/GIT_REFLOW_PR_MSG"
 
           File.open(pull_request_msg_file, 'w') do |file|
-            file.write(options[:title] || GitReflow.current_branch)
+            file.write(options[:title] || GitReflow.pull_request_template || GitReflow.current_branch)
           end
 
           GitReflow.run("#{GitReflow.git_editor_command} #{pull_request_msg_file}", with_system: true)

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -28,10 +28,12 @@ module GitReflow
     end
 
     def pull_request_template
-      filenames_to_try = %w( .github/PULL_REQUEST_TEMPLATE.md
-                             .github/PULL_REQUEST_TEMPLATE
+      filenames_to_try = %w( github/PULL_REQUEST_TEMPLATE.md
+                             github/PULL_REQUEST_TEMPLATE
                              PULL_REQUEST_TEMPLATE.md
-                             PULL_REQUEST_TEMPLATE )
+                             PULL_REQUEST_TEMPLATE ).map do |file|
+        "#{git_root_dir}/#{file}"
+      end
 
       filename = filenames_to_try.detect do |file|
         File.exist? file

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -27,6 +27,19 @@ module GitReflow
       run("git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'", loud: false).strip
     end
 
+    def pull_request_template
+      filenames_to_try = %w( .github/PULL_REQUEST_TEMPLATE.md
+                             .github/PULL_REQUEST_TEMPLATE
+                             PULL_REQUEST_TEMPLATE.md
+                             PULL_REQUEST_TEMPLATE )
+
+      filename = filenames_to_try.detect do |file|
+        File.exist? file
+      end
+
+      File.read filename
+    end
+
     def get_first_commit_message
       run('git log --pretty=format:"%s" --no-merges -n 1', loud: false).strip
     end

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -37,7 +37,7 @@ module GitReflow
         File.exist? file
       end
 
-      File.read filename
+      File.read filename if filename
     end
 
     def get_first_commit_message

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -56,6 +56,30 @@ describe GitReflow::GitHelpers do
     it      { expect{ subject }.to have_run_command_silently "git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'" }
   end
 
+  describe ".pull_request_template" do
+    subject { Gitacular.pull_request_template }
+
+    context "template file exists" do
+      let(:root_dir) { "/some_repo" }
+      let(:template_content) { "Template content" }
+
+      before do
+        allow(Gitacular).to receive(:git_root_dir).and_return(root_dir)
+        allow(File).to receive(:exist?).with("#{root_dir}/github/PULL_REQUEST_TEMPLATE.md").and_return(true)
+        allow(File).to receive(:read).with("#{root_dir}/github/PULL_REQUEST_TEMPLATE.md").and_return(template_content)
+      end
+      it { is_expected.to eq template_content }
+    end
+
+    context "template file does not exist" do
+      before do
+        allow(File).to receive(:exist?).and_return(false)
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
+
   describe ".get_first_commit_message" do
     subject { Gitacular.get_first_commit_message }
     it      { expect{ subject }.to have_run_command_silently 'git log --pretty=format:"%s" --no-merges -n 1' }


### PR DESCRIPTION
GitHub allows you to define a [pull request template (e.g. to include a release note section)](https://github.com/blog/2111-issue-and-pull-request-templates), which in my opinion is great for standardizing workflow across teams.

This PR makes the default `git-reflow review` message fall back to a Github pull request template if no `-m` parameter was given