### PR TITLE
Use $EDITOR as text editor fallback

### DIFF
--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -21,7 +21,9 @@ module GitReflow
   include GitHelpers
   extend self
 
-  DEFAULT_EDITOR = "#{ENV['EDITOR']}".freeze || "vi".freeze
+  def default_editor
+    "#{ENV['EDITOR']}".freeze || "vi".freeze
+  end
 
   def status(destination_branch)
     pull_request = git_server.find_open_pull_request( :from => current_branch, :to => destination_branch )

--- a/lib/git_reflow/commands/setup.rb
+++ b/lib/git_reflow/commands/setup.rb
@@ -26,8 +26,8 @@ command :setup do |c|
     GitReflow::Config.set "constants.approvalRegex", GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX.to_s, local: reflow_options[:project_only]
 
     if GitReflow::Config.get('core.editor').length <= 0
-      GitReflow::Config.set('core.editor', GitReflow::DEFAULT_EDITOR, local: reflow_options[:project_only])
-      GitReflow.say "Updated git's editor (via git config key 'core.editor') to: #{GitReflow::DEFAULT_EDITOR}.", :notice
+      GitReflow::Config.set('core.editor', GitReflow.default_editor, local: reflow_options[:project_only])
+      GitReflow.say "Updated git's editor (via git config key 'core.editor') to: #{GitReflow.default_editor}.", :notice
     end
   end
 end

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -10,7 +10,7 @@ module GitReflow
     end
 
     def git_editor_command
-      GitReflow::Config.get('core.editor') || GitReflow::DEFAULT_EDITOR
+      GitReflow::Config.get('core.editor') || GitReflow.default_editor
     end
 
     def remote_user

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -10,7 +10,7 @@ module GitReflow
     end
 
     def git_editor_command
-      GitReflow::Config.get('core.editor') || ENV['EDITOR']
+      GitReflow::Config.get('core.editor') || GitReflow::DEFAULT_EDITOR
     end
 
     def remote_user

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -10,7 +10,7 @@ module GitReflow
     end
 
     def git_editor_command
-      @git_editor_command ||= GitReflow::Config.get('core.editor')
+      GitReflow::Config.get('core.editor') || ENV['EDITOR']
     end
 
     def remote_user

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -21,7 +21,7 @@ describe GitReflow::GitHelpers do
 
   describe '.git_editor_command' do
     subject { Gitacular.git_editor_command }
-    before { allow(ENV).to receive(:[]).with('EDITOR').and_return 'vim' }
+    before { ENV['editor'] = 'vim' }
 
     it 'defaults to GitReflow config' do
       allow(GitReflow::Config).to receive(:get).with('core.editor').and_return 'nano'

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -21,7 +21,7 @@ describe GitReflow::GitHelpers do
 
   describe '.git_editor_command' do
     subject { Gitacular.git_editor_command }
-    before { ENV['editor'] = 'vim' }
+    before { ENV['EDITOR'] = 'vim' }
 
     it 'defaults to GitReflow config' do
       allow(GitReflow::Config).to receive(:get).with('core.editor').and_return 'nano'

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -22,7 +22,6 @@ describe GitReflow::GitHelpers do
   describe '.git_editor_command' do
     subject { Gitacular.git_editor_command }
     before { allow(ENV).to receive(:[]).with('EDITOR').and_return 'vim' }
-    before { allow(ENV).to receive(:[]).with('HOME').and_return '/home/timraasveld' }
 
     it 'defaults to GitReflow config' do
       allow(GitReflow::Config).to receive(:get).with('core.editor').and_return 'nano'

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -19,6 +19,24 @@ describe GitReflow::GitHelpers do
     it      { expect{ subject }.to have_run_command_silently "git rev-parse --show-toplevel" }
   end
 
+  describe '.git_editor_command' do
+    subject { Gitacular.git_editor_command }
+    before { allow(ENV).to receive(:[]).with('EDITOR').and_return 'vim' }
+    before { allow(ENV).to receive(:[]).with('HOME').and_return '/home/timraasveld' }
+
+    it 'defaults to GitReflow config' do
+      allow(GitReflow::Config).to receive(:get).with('core.editor').and_return 'nano'
+
+      expect(subject).to eq 'nano'
+    end
+
+    it 'falls back to the environment variable $EDITOR' do
+      allow(GitReflow::Config).to receive(:get).with('core.editor').and_return nil
+
+      expect(subject).to eq 'vim'
+    end
+  end
+
   describe ".remote_user" do
     subject { Gitacular.remote_user }
 


### PR DESCRIPTION
If no editor is set up specifically for gitreflow, in its current state it would just skip editing the PR message when using `git-reflow review`, which I think is never desirable.

This makes it fall back to `$EDITOR` which is set up on most unixy systems, and which I believe git also uses for commit messages