### PR TITLE
[192] Allow delivery to custom base branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,11 @@ dependencies:
     - >
       case $CIRCLE_NODE_INDEX in
        0)
+         rvm-exec 2.1.9 gem install bundler
          rvm-exec 2.1.9 bash -c "bundle check --path=vendor/bundle_2.1 || bundle install --path=vendor/bundle_2.1"
          ;;
        1)
+         rvm-exec 2.2.5 gem install bundler
          rvm-exec 2.2.5 bash -c "bundle check --path=vendor/bundle_2.2 || bundle install --path=vendor/bundle_2.2"
          ;;
        2)

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -100,10 +100,10 @@ module GitReflow
   end
 
   def deliver(options = {})
-    base_branch = options[:base] || 'master'
+    options[:base] ||= 'master'
 
     begin
-      existing_pull_request = git_server.find_open_pull_request( :from => current_branch, :to => base_branch )
+      existing_pull_request = git_server.find_open_pull_request( from: current_branch, to: options[:base] )
 
       if existing_pull_request.nil?
         say "No pull request exists for #{remote_user}:#{current_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted
@@ -111,7 +111,7 @@ module GitReflow
 
         if existing_pull_request.good_to_merge?(force: options[:skip_lgtm])
           # displays current status and prompts user for confirmation
-          self.status base_branch
+          self.status options[:base]
           existing_pull_request.merge!(options)
         else
           say existing_pull_request.rejection_message, :deliver_halted

--- a/lib/git_reflow/commands/deliver.rb
+++ b/lib/git_reflow/commands/deliver.rb
@@ -4,8 +4,12 @@ long_desc 'merge your feature branch down to your base branch, and cleanup your 
 command :deliver do |c|
   c.desc 'merge your feature branch down to your base branch, and cleanup your feature branch'
   c.switch [:f, :'skip-lgtm'], desc: 'skip the lgtm checks and deliver your feature branch'
-  c.action do |global_options,options,args|
-    deliver_options = {:skip_lgtm => options[:'skip-lgtm']}
+  c.action do |global_options, options, args|
+    deliver_options = {
+      base:      args[0],
+      skip_lgtm: options[:'skip-lgtm']
+    }
+
     GitReflow.deliver deliver_options
   end
 end

--- a/spec/lib/git_reflow_spec.rb
+++ b/spec/lib/git_reflow_spec.rb
@@ -207,6 +207,14 @@ describe GitReflow do
       subject
     end
 
+    context "and a base branch is provided" do
+      let(:inputs) { { title: "new-feature", message: "message", head: "reenhanced:new-feature", base: 'live'}}
+      it "looks for a pull request with the custom base branch" do
+        expect(github).to receive(:find_open_pull_request).with(from: branch, to: inputs[:base])
+        subject
+      end
+    end
+
     context "and pull request exists for the feature branch to the destination branch" do
       before do
         allow(github).to receive(:build_status).and_return(build_status)


### PR DESCRIPTION
As referenced in #192, this enables use of `deliver` command with a custom base branch