### PR TITLE
All commands that are run through reflow (except git-config) are now blocking

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     git_reflow (0.8.6)
       colorize (>= 0.7.0)
       github_api (= 0.15.0)
-      gli (= 2.14.0)
+      gli (= 2.15.0)
       highline
       httpclient
       rack (>= 1.2, < 2)
@@ -18,7 +18,7 @@ GEM
       bundler
       rake
       thor (>= 0.14.0)
-    byebug (9.0.4)
+    byebug (9.0.6)
     chronic (0.10.2)
     coderay (1.1.1)
     colorize (0.8.1)
@@ -26,7 +26,7 @@ GEM
       safe_yaml (~> 1.0.0)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    diff-lcs (1.2.5)
+    diff-lcs (1.3)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.9.2)
@@ -38,12 +38,11 @@ GEM
       hashie (>= 3.4)
       mime-types (>= 1.16, < 3.0)
       oauth2 (~> 1.0)
-    gli (2.14.0)
-    hashdiff (0.3.0)
+    gli (2.15.0)
+    hashdiff (0.3.2)
     hashie (3.5.5)
     highline (1.7.8)
     httpclient (2.8.3)
-    json (1.8.3)
     jwt (1.5.6)
     method_source (0.8.2)
     mime-types (2.99.3)
@@ -59,17 +58,16 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    pry (0.10.3)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.4.0)
+    pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
     rack (1.6.5)
-    rake (11.1.2)
-    rdoc (4.2.2)
-      json (~> 1.4)
+    rake (11.3.0)
+    rdoc (5.1.0)
     reenhanced_bitbucket_api (0.3.2)
       faraday (~> 0.9.0)
       faraday_middleware (~> 0.9.0)
@@ -93,9 +91,9 @@ GEM
     safe_yaml (1.0.4)
     simple_oauth (0.3.1)
     slop (3.6.0)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.6)
-    webmock (2.0.3)
+    webmock (2.3.2)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
@@ -117,4 +115,4 @@ DEPENDENCIES
   wwtd (= 1.3.0)
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/git_reflow.gemspec
+++ b/git_reflow.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('wwtd', '1.3.0')
 
   s.add_dependency('colorize', '>= 0.7.0')
-  s.add_dependency('gli', '2.14.0')
+  s.add_dependency('gli', '2.15.0')
   s.add_dependency('highline')
   s.add_dependency('httpclient')
   s.add_dependency('github_api', '0.15.0')

--- a/lib/git_reflow.rb
+++ b/lib/git_reflow.rb
@@ -26,6 +26,12 @@ require 'git_reflow/sandbox'
 require 'git_reflow/workflow'
 require 'git_reflow/workflows/core'
 
+# This is a work around to silence logger spam from hashie
+# https://github.com/intridea/hashie/issues/394
+require "hashie"
+require "hashie/logger"
+Hashie.logger = Logger.new(nil)
+
 module GitReflow
   include Sandbox
   include GitHelpers

--- a/lib/git_reflow/config.rb
+++ b/lib/git_reflow/config.rb
@@ -10,9 +10,9 @@ module GitReflow
       else
         local = local ? '--local ' : ''
         if all
-          new_value = GitReflow::Sandbox.run "git config #{local}--get-all #{key}", loud: false
+          new_value = GitReflow::Sandbox.run "git config #{local}--get-all #{key}", loud: false, blocking: false
         else
-          new_value = GitReflow::Sandbox.run "git config #{local}--get #{key}", loud: false
+          new_value = GitReflow::Sandbox.run "git config #{local}--get #{key}", loud: false, blocking: false
         end
         instance_variable_set(:"@#{key.tr('.-', '_')}", new_value.strip)
       end
@@ -21,28 +21,28 @@ module GitReflow
     def set(key, value, local: false)
       value = "#{value}".strip
       if local
-        GitReflow::Sandbox.run "git config --replace-all #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config --replace-all #{key} \"#{value}\"", loud: false, blocking: false
       else
-        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --replace-all #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --replace-all #{key} \"#{value}\"", loud: false, blocking: false
       end
     end
 
     def unset(key, value: nil, local: false)
       value = (value.nil?) ? "" : "\"#{value}\""
       if local
-        GitReflow::Sandbox.run "git config --unset-all #{key} #{value}", loud: false
+        GitReflow::Sandbox.run "git config --unset-all #{key} #{value}", loud: false, blocking: false
       else
-        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --unset-all #{key} #{value}", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --unset-all #{key} #{value}", loud: false, blocking: false
       end
     end
 
     def add(key, value, local: false, global: false)
       if global
-        GitReflow::Sandbox.run "git config --global --add #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config --global --add #{key} \"#{value}\"", loud: false, blocking: false
       elsif local
-        GitReflow::Sandbox.run "git config --add #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config --add #{key} \"#{value}\"", loud: false, blocking: false
       else
-        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --add #{key} \"#{value}\"", loud: false
+        GitReflow::Sandbox.run "git config -f #{CONFIG_FILE_PATH} --add #{key} \"#{value}\"", loud: false, blocking: false
       end
     end
   end

--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -126,7 +126,7 @@ module GitReflow
                   "commit_title"   => "#{options[:title]}",
                   "commit_message" => "#{options[:body]}",
                   "sha"            => "#{self.head.sha}",
-                  "squash"         => !(options[:squash] == false)
+                  "merge_method"   => !(options[:squash] == false) ? "squash" : "merge"
                 }
               )
 

--- a/lib/git_reflow/sandbox.rb
+++ b/lib/git_reflow/sandbox.rb
@@ -12,16 +12,19 @@ module GitReflow
     }
 
     def run(command, options = {})
-      options = { loud: true }.merge(options)
+      options = { loud: true, blocking: true }.merge(options)
 
       if options[:with_system] == true
         system(command)
-      elsif options[:loud] == true
-        output = %x{#{command}}
-        puts output
-        output
       else
-        %x{#{command}}
+        output = %x{#{command}}
+
+        if options[:blocking] == true && !$?.success?
+          abort "\`#{command}\` failed to run."
+        else
+          puts output if options[:loud] == true
+          output
+        end
       end
     end
 

--- a/spec/lib/git_reflow/config_spec.rb
+++ b/spec/lib/git_reflow/config_spec.rb
@@ -3,72 +3,72 @@ require 'spec_helper'
 describe GitReflow::Config do
   describe ".get(key)" do
     subject { GitReflow::Config.get('chucknorris.roundhouse') }
-    it      { expect{ subject }.to have_run_command_silently 'git config --get chucknorris.roundhouse' }
+    it      { expect{ subject }.to have_run_command_silently 'git config --get chucknorris.roundhouse', blocking: false }
 
     context "and getting all values" do
       subject { GitReflow::Config.get('chucknorris.roundhouse-kick', all: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --get-all chucknorris.roundhouse-kick' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --get-all chucknorris.roundhouse-kick', blocking: false }
 
       context "and checking locally only" do
         subject { GitReflow::Config.get('chucknorris.jump', local: true) }
-        it      { expect{ subject }.to have_run_command_silently 'git config --local --get chucknorris.jump' }
+        it      { expect{ subject }.to have_run_command_silently 'git config --local --get chucknorris.jump', blocking: false }
       end
     end
 
     context "and checking for updates" do
       before  { GitReflow::Config.get('chucknorris.roundhouse') }
       subject { GitReflow::Config.get('chucknorris.roundhouse') }
-      it      { expect{ subject }.to_not have_run_command_silently 'git config --get chucknorris.roundhouse-kick' }
+      it      { expect{ subject }.to_not have_run_command_silently 'git config --get chucknorris.roundhouse-kick', blocking: false }
     end
 
     context "and checking locally only" do
       subject { GitReflow::Config.get('chucknorris.smash', local: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --local --get chucknorris.smash' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --local --get chucknorris.smash', blocking: false }
     end
   end
 
   describe ".set(key)" do
     subject { GitReflow::Config.set('chucknorris.roundhouse', 'to the face') }
-    it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --replace-all chucknorris.roundhouse \"to the face\"" }
+    it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --replace-all chucknorris.roundhouse \"to the face\"", blocking: false }
 
     context "for current project only" do
       subject { GitReflow::Config.set('chucknorris.roundhouse', 'to the face', local: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --replace-all chucknorris.roundhouse "to the face"' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --replace-all chucknorris.roundhouse "to the face"', blocking: false }
     end
   end
 
   describe ".unset(key)" do
     subject { GitReflow::Config.unset('chucknorris.roundhouse') }
-    it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --unset-all chucknorris.roundhouse " }
+    it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --unset-all chucknorris.roundhouse ", blocking: false }
 
     context "for multi-value keys" do
       subject { GitReflow::Config.unset('chucknorris.roundhouse', value: 'to the face') }
-      it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --unset-all chucknorris.roundhouse \"to the face\"" }
+      it      { expect{ subject }.to have_run_command_silently "git config -f #{ENV['HOME']}/.gitconfig.reflow --unset-all chucknorris.roundhouse \"to the face\"", blocking: false }
     end
 
     context "for current project only" do
       subject { GitReflow::Config.unset('chucknorris.roundhouse', local: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --unset-all chucknorris.roundhouse ' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --unset-all chucknorris.roundhouse ', blocking: false }
 
       context "for multi-value keys" do
         subject { GitReflow::Config.unset('chucknorris.roundhouse', value: 'to the face', local: true) }
-        it      { expect{ subject }.to have_run_command_silently 'git config --unset-all chucknorris.roundhouse "to the face"' }
+        it      { expect{ subject }.to have_run_command_silently 'git config --unset-all chucknorris.roundhouse "to the face"', blocking: false }
       end
     end
   end
 
   describe ".add(key)" do
     subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face') }
-    it      { expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add chucknorris.roundhouse \"to the face\"" }
+    it      { expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add chucknorris.roundhouse \"to the face\"", blocking: false }
 
     context "for current project only" do
       subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face', local: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --add chucknorris.roundhouse "to the face"' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --add chucknorris.roundhouse "to the face"', blocking: false }
     end
 
     context "globally" do
       subject { GitReflow::Config.add('chucknorris.roundhouse', 'to the face', global: true) }
-      it      { expect{ subject }.to have_run_command_silently 'git config --global --add chucknorris.roundhouse "to the face"' }
+      it      { expect{ subject }.to have_run_command_silently 'git config --global --add chucknorris.roundhouse "to the face"', blocking: false }
     end
   end
 end

--- a/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
@@ -501,7 +501,7 @@ describe GitReflow::GitServer::GitHub::PullRequest do
             "commit_title"   => "#{inputs[:title]}",
             "commit_message" => "#{inputs[:message]}\n",
             "sha"            => pr.head.sha,
-            "squash"         => false
+            "merge_method"   => "merge"
           }
         )
 

--- a/spec/lib/git_reflow/git_server/git_hub_spec.rb
+++ b/spec/lib/git_reflow/git_server/git_hub_spec.rb
@@ -103,10 +103,10 @@ describe GitReflow::GitServer::GitHub do
         end
 
         it "creates git config keys for github connections" do
-          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
-          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
-          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\"", blocking: false
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\"", blocking: false
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\"", blocking: false
+          expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\"", blocking: false
         end
 
         context "exclusive to project" do
@@ -118,16 +118,16 @@ describe GitReflow::GitServer::GitHub do
           end
 
           it "creates _local_ git config keys for github connections" do
-            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
-            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
-            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\"", blocking: false
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\"", blocking: false
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\"", blocking: false
+            expect{ subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\"", blocking: false
 
-            expect{ subject }.to have_run_command_silently "git config --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\""
-            expect{ subject }.to have_run_command_silently "git config --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\""
-            expect{ subject }.to have_run_command_silently "git config --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-            expect{ subject }.to have_run_command_silently "git config --replace-all reflow.git-server \"GitHub\""
-            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add reflow.local-projects \"#{user}/#{repo}\""
+            expect{ subject }.to have_run_command_silently "git config --replace-all github.site \"#{GitReflow::GitServer::GitHub.site_url}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config --replace-all github.endpoint \"#{GitReflow::GitServer::GitHub.api_endpoint}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config --replace-all reflow.git-server \"GitHub\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --add reflow.local-projects \"#{user}/#{repo}\"", blocking: false
           end
         end
 
@@ -135,10 +135,10 @@ describe GitReflow::GitServer::GitHub do
           let(:github) { GitReflow::GitServer::GitHub.new(enterprise: true) }
           before { allow(GitReflow::GitServer::GitHub).to receive(:@using_enterprise).and_return(true) }
           it "creates git config keys for github connections" do
-            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{enterprise_site}\""
-            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{enterprise_api}\""
-            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\""
-            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\""
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.site \"#{enterprise_site}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.endpoint \"#{enterprise_api}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all github.oauth-token \"#{oauth_token_hash[:token]}\"", blocking: false
+            expect{ subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all reflow.git-server \"GitHub\"", blocking: false
           end
         end
       end

--- a/spec/lib/git_reflow/sandbox_spec.rb
+++ b/spec/lib/git_reflow/sandbox_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+RSpec.describe GitReflow::Sandbox do
+  describe ".run" do
+    it "is blocking by default when the command exits with a failure" do
+      allow(GitReflow::Sandbox).to receive(:run).and_call_original
+      expect { GitReflow::Sandbox.run("ls wtf") }.to raise_error SystemExit, "\`ls wtf\` failed to run."
+    end
+
+    it "when blocking is flagged off, the command exits silently" do
+      allow(GitReflow::Sandbox).to receive(:run).and_call_original
+      expect { GitReflow::Sandbox.run("ls wtf", blocking: false) }.to_not raise_error SystemExit
+    end
+  end
+end

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -21,7 +21,7 @@ describe GitReflow::Workflows::Core do
       })
     end
 
-    specify { expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all core.editor \"#{GitReflow.default_editor}\"" }
+    specify { expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all core.editor \"#{GitReflow.default_editor}\"", blocking: false }
     specify { expect { subject }.to have_said "Updated git's editor (via git config key 'core.editor') to: #{GitReflow.default_editor}.", :notice }
 
     context "core.editor git config has already been set" do
@@ -30,7 +30,7 @@ describe GitReflow::Workflows::Core do
         allow(GitReflow::Config).to receive(:get).with('core.editor').and_return('emacs')
       end
 
-      specify { expect { subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all core.editor \"#{GitReflow.default_editor}\"" }
+      specify { expect { subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all core.editor \"#{GitReflow.default_editor}\"", blocking: false }
     end
 
     context "git-reflow has not been setup before" do
@@ -42,15 +42,15 @@ describe GitReflow::Workflows::Core do
 
       it "creates a .gitconfig.reflow file and includes it in the user's global git config" do
         expect { subject }.to have_run_command "touch #{GitReflow::Config::CONFIG_FILE_PATH}"
-        expect { subject }.to have_run_command_silently "git config --global --add include.path \"#{GitReflow::Config::CONFIG_FILE_PATH}\""
+        expect { subject }.to have_run_command_silently "git config --global --add include.path \"#{GitReflow::Config::CONFIG_FILE_PATH}\"", blocking: false
 
         expect { subject }.to have_said "Created #{GitReflow::Config::CONFIG_FILE_PATH} for git-reflow specific configurations.", :notice
         expect { subject }.to have_said "Added #{GitReflow::Config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
       end
 
       it "sets the default approval minimum and regex" do
-        expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.minimumApprovals \"\""
-        expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.approvalRegex \"#{GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX}\""
+        expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.minimumApprovals \"\"", blocking: false
+        expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.approvalRegex \"#{GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX}\"", blocking: false
       end
 
       context "when setting a custom approval minimum" do
@@ -60,7 +60,7 @@ describe GitReflow::Workflows::Core do
           })
         end
 
-        specify { expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.minimumApprovals \"3\"" }
+        specify { expect { subject }.to have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all constants.minimumApprovals \"3\"", blocking: false }
       end
     end
 
@@ -75,7 +75,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "doesn't add the .gitconfig.reflow file to the git-config include path" do
-        expect { subject }.to_not have_run_command_silently "git config --global --add include.path \"#{GitReflow::Config::CONFIG_FILE_PATH}\""
+        expect { subject }.to_not have_run_command_silently "git config --global --add include.path \"#{GitReflow::Config::CONFIG_FILE_PATH}\"", blocking: false
 
         expect { subject }.to_not have_said "Added #{GitReflow::Config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
       end
@@ -499,7 +499,7 @@ describe GitReflow::Workflows::Core do
         end
 
         it "sets the reflow.staging-branch git config to 'staging'" do
-          expect { subject }.to have_run_command_silently "git config --replace-all reflow.staging-branch \"staging\""
+          expect { subject }.to have_run_command_silently "git config --replace-all reflow.staging-branch \"staging\"", blocking: false
         end
 
         it "checks out and updates the staging branch" do


### PR DESCRIPTION
* Adds `blocking` option to command line runner
* Fixes issue causing reflow to continue running after command failures
* Updates rspec command line helpers to check for explicit options
* Updates Github's squash merge to reflect recent API changes

Fixes #206