### PR TITLE
Updates Github merge request to use new `merge_method` param

### DIFF
--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -118,6 +118,9 @@ module GitReflow
 
               options[:body] = "#{options[:message]}\n" if options[:body].nil? and "#{options[:message]}".length > 0
 
+              merge_method   = options[:merge_method] || GitReflow::Config.get("reflow.merge-method")
+              merge_method   = "squash" if "#{merge_method}".length < 1
+
               merge_response = GitReflow::GitServer::GitHub.connection.pull_requests.merge(
                 "#{GitReflow.git_server.class.remote_user}",
                 "#{GitReflow.git_server.class.remote_repo_name}",
@@ -126,7 +129,7 @@ module GitReflow
                   "commit_title"   => "#{options[:title]}",
                   "commit_message" => "#{options[:body]}",
                   "sha"            => "#{self.head.sha}",
-                  "merge_method"   => !(options[:squash] == false) ? "squash" : "merge"
+                  "merge_method"   => merge_method
                 }
               )
 

--- a/lib/git_reflow/git_server/pull_request.rb
+++ b/lib/git_reflow/git_server/pull_request.rb
@@ -196,11 +196,20 @@ module GitReflow
           GitReflow.update_current_branch
           GitReflow.fetch_destination(self.base_branch_name)
 
-          message = commit_message_for_merge
+          message      = commit_message_for_merge
+          merge_method = options[:merge_method] || GitReflow::Config.get("reflow.merge-method")
+          merge_method = "squash" if "#{merge_method}".length < 1
+
 
           GitReflow.run_command_with_label "git checkout #{self.base_branch_name}"
           GitReflow.run_command_with_label "git pull origin #{self.base_branch_name}"
-          GitReflow.run_command_with_label "git merge #{options[:squash] == false ? '' : '--squash '}#{self.feature_branch_name}"
+
+          case merge_method
+          when /squash/i
+            GitReflow.run_command_with_label "git merge --squash #{self.feature_branch_name}"
+          else
+            GitReflow.run_command_with_label "git merge #{self.feature_branch_name}"
+          end
 
           GitReflow.append_to_squashed_commit_message(message) if message.length > 0
 

--- a/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
@@ -480,10 +480,10 @@ describe GitReflow::GitServer::GitHub::PullRequest do
     context "and not suqash merging" do
       let(:inputs) do
         {
-          base:    "base_branch",
-          title:   "title",
-          message: "message",
-          squash:  false
+          base:         "base_branch",
+          title:        "title",
+          message:      "message",
+          merge_method: "merge"
         }
       end
 

--- a/spec/lib/git_reflow/git_server/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/pull_request_spec.rb
@@ -411,10 +411,10 @@ describe GitReflow::GitServer::PullRequest do
         context "and NOT squash merging" do
           let(:inputs) do
             {
-              base:    "base_branch",
-              title:   "title",
-              message: "message",
-              squash:  false
+              base:         "base_branch",
+              title:        "title",
+              message:      "message",
+              merge_method: "merge"
             }
           end
 


### PR DESCRIPTION
This allows users to now use any merge method provided by Github: `merge`, `squash`, or `rebase` :smile: