### PR TITLE
Adds checks for new GH reviews when delivering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_reflow (0.8.8)
+    git_reflow (0.8.9)
       colorize (>= 0.7.0)
       github_api (= 0.15.0)
       gli (= 2.15.0)

--- a/lib/git_reflow/commands/start.rb
+++ b/lib/git_reflow/commands/start.rb
@@ -12,11 +12,7 @@ command :start do |c|
   c.flag [:b,:base], default_value: 'master'
   c.action do |global_options, options, args|
 
-    if args.empty?
-      raise "usage: git-reflow start [new-branch-name]"
-    else
-      GitReflow.start feature_branch: args[0], base: options[:base]
-    end
+    GitReflow.start feature_branch: args[0], base: options[:base]
 
   end
 end

--- a/lib/git_reflow/version.rb
+++ b/lib/git_reflow/version.rb
@@ -1,3 +1,3 @@
 module GitReflow
-  VERSION = "0.8.8"
+  VERSION = "0.8.9"
 end

--- a/lib/git_reflow/workflow.rb
+++ b/lib/git_reflow/workflow.rb
@@ -11,8 +11,10 @@ module GitReflow
     def self.current
       workflow_file = GitReflow::Config.get('reflow.workflow')
       if workflow_file.length > 0 and File.exists?(workflow_file)
+        GitReflow.logger.debug "Using workflow: #{workflow_file}"
         eval(File.read(workflow_file))
       else
+        GitReflow.logger.debug "Using core workflow..."
         GitReflow::Workflows::Core
       end
     end

--- a/spec/fixtures/pull_requests/review.json.erb
+++ b/spec/fixtures/pull_requests/review.json.erb
@@ -1,0 +1,35 @@
+{
+  "id": <%= id || 1 %>,
+  "user": {
+    "login": "<%= author %>",
+    "id": 1,
+    "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/<%= author %>",
+    "html_url": "https://github.com/octocat",
+    "followers_url": "https://api.github.com/users/<%= author %>/followers",
+    "following_url": "https://api.github.com/users/<%= author %>/following{/other_user}",
+    "gists_url": "https://api.github.com/users/<%= author %>/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/<%= author %>/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/<%= author %>/subscriptions",
+    "organizations_url": "https://api.github.com/users/<%= author %>/orgs",
+    "repos_url": "https://api.github.com/users/<%= author %>/repos",
+    "events_url": "https://api.github.com/users/<%= author %>/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/<%= author %>/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "<%= body || "Nice." %>",
+  "commit_id": "<%= commit_id || "ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091"%>",
+  "state": "<%= state || "PENDING" %>",
+  "html_url": "https://github.com/Hello-World/pull/<%= pull_request_number %>#pullrequestreview-<%= id || 1 %>",
+  "pull_request_url": "https://api.github.com/repos/octocat/Hello-World/pulls/<%= pull_request_number %>",
+  "_links": {
+    "html": {
+      "href": "https://github.com/octocat/Hello-World/pull/<%= pull_request_number %>#pullrequestreview-<%= id || 1 %>"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/octocat/Hello-World/pulls/<%= pull_request_number %>"
+    }
+  }
+}

--- a/spec/fixtures/pull_requests/reviews.json.erb
+++ b/spec/fixtures/pull_requests/reviews.json.erb
@@ -1,0 +1,16 @@
+[
+  <% reviews_json = [] %>
+  <% reviews.each_with_index do |review, index| %>
+    <% reviews_json << Fixture.new('pull_requests/review.json.erb',
+                    id: index,
+                    author: review[:author],
+                    pull_request_number: pull_request_number,
+                    repo_owner: repo_owner,
+                    repo_name: repo_name,
+                    body: review[:body] || 'Hammer time',
+                    state: review[:state] || 'PENDING',
+                    commit_id: review[:commit_id] || 'ecdd80bb57125d7ba9641ffaa4d7d2c19d3f3091'
+                   ).to_s %>
+  <% end %>
+  <%= reviews_json.join(", ") %>
+]

--- a/spec/lib/git_reflow/logger_spec.rb
+++ b/spec/lib/git_reflow/logger_spec.rb
@@ -6,13 +6,5 @@ describe GitReflow::Logger do
       logger = described_class.new
       expect(logger.instance_variable_get("@logdev").dev.path).to eq GitReflow::Logger::DEFAULT_LOG_FILE
     end
-
-    context "when a log path is configured " do
-      it "initializes a new logger with the given path" do
-        allow(GitReflow::Config).to receive(:get).with("reflow.log_file_path").and_return("kenny-loggins.log")
-        logger = described_class.new
-        expect(logger.instance_variable_get("@logdev").dev.path).to eq "kenny-loggins.log"
-      end
-    end
   end
 end

--- a/spec/lib/git_reflow/sandbox_spec.rb
+++ b/spec/lib/git_reflow/sandbox_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GitReflow::Sandbox do
   describe ".run" do
     it "is blocking by default when the command exits with a failure" do
       allow(GitReflow::Sandbox).to receive(:run).and_call_original
-      expect { GitReflow::Sandbox.run("ls wtf") }.to raise_error SystemExit, "\`ls wtf\` failed to run."
+      expect { GitReflow::Sandbox.run("ls wtf") }.to raise_error SystemExit, "\"ls wtf\" failed to run."
     end
 
     it "when blocking is flagged off, the command exits silently" do


### PR DESCRIPTION
This adds Github's new Reviews into consideration when checking for PR
approvals.  For now I've opted to ignore review comments and just check for approval
presence. This also removes the hard requirement of a branch name when starting
a new feature (we already have checks in place in the `GitReflow.start` method
itself); and this will allow future implementations of Trello/Pivotal Tracker
:smile:.

* Removes `new-branch-name` hard requirement from `git-reflow start` command
* Adds GH's new Reviews into consideration for approval matching
* Adds extra logging for usage of custom workflows

Fixes #207
