### PR TITLE
Remove lingering `skip_lgtm` options in favor of `force` option

### DIFF
--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -87,7 +87,7 @@ module GitReflow
         def merge!(options = {})
 
           # fallback to default merge process if user "forces" merge
-          if(options[:skip_lgtm])
+          if(options[:force])
             super options
           else
             if deliver?

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -204,8 +204,6 @@ module GitReflow
             if existing_pull_request.good_to_merge?(force: params[:force])
               # displays current status and prompts user for confirmation
               self.status destination_branch: params[:base]
-              # TODO: change name of this in the merge! method
-              params[:skip_lgtm] = params[:force] if params[:force]
               existing_pull_request.merge!(params)
             else
               say existing_pull_request.rejection_message, :deliver_halted

--- a/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
@@ -490,10 +490,10 @@ describe GitReflow::GitServer::GitHub::PullRequest do
     context "and force-merging" do
       let(:inputs) do
         {
-          base:      "base_branch",
-          title:     "title",
-          message:   "message",
-          skip_lgtm: true
+          base:    "base_branch",
+          title:   "title",
+          message: "message",
+          force:   true
         }
       end
 

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -589,7 +589,7 @@ describe GitReflow::Workflows::Core do
 
           before do
             allow(existing_gh_pull_request).to receive(:good_to_merge?).with(force: true).and_return(true)
-            allow(existing_gh_pull_request).to receive(:merge!).with(force: true, base: 'master', skip_lgtm: true)
+            allow(existing_gh_pull_request).to receive(:merge!).with(force: true, base: 'master')
           end
 
           it "displays the status of the PR" do
@@ -598,7 +598,7 @@ describe GitReflow::Workflows::Core do
           end
 
           it "merges the feature branch anyway" do
-            expect(existing_gh_pull_request).to receive(:merge!).with(force: true, base: 'master', skip_lgtm: true)
+            expect(existing_gh_pull_request).to receive(:merge!).with(force: true, base: 'master')
             subject
           end
         end

--- a/spec/lib/git_reflow/workflows/flat_merge_spec.rb
+++ b/spec/lib/git_reflow/workflows/flat_merge_spec.rb
@@ -50,7 +50,7 @@ describe 'FlatMerge' do
       end
 
       it "doesn't squash merge" do
-        expect(pr).to receive(:merge!).with(base: 'master', squash: false, force: true, skip_lgtm: true)
+        expect(pr).to receive(:merge!).with(base: 'master', squash: false, force: true)
         subject
       end
     end


### PR DESCRIPTION
We started using the `force` option for `deliver` a while ago and I forgot to rip out the old `skip_lgtm` references.
