### PR TITLE
Fixes loading of custom workflow file to once per session

### DIFF
--- a/lib/git_reflow/workflow.rb
+++ b/lib/git_reflow/workflow.rb
@@ -9,6 +9,7 @@ module GitReflow
 
     # @nodoc
     def self.current
+      return @current unless @current.nil?
       # First look for a "Workflow" file in the current directory, then check
       # for a global Workflow file stored in git-reflow git config.
       loaded_local_workflow  = GitReflow::Workflows::Core.load_workflow "#{GitReflow.git_root_dir}/Workflow"
@@ -20,7 +21,7 @@ module GitReflow
 
       GitReflow.logger.debug "Using core workflow..." unless loaded_local_workflow || loaded_global_workflow
 
-      GitReflow::Workflows::Core
+      @current = GitReflow::Workflows::Core
     end
 
     # @nodoc
@@ -29,6 +30,7 @@ module GitReflow
     # the scenario at hand.
     def self.reset!
       remove_const(:Core) if const_defined? :Core
+      @current = nil
       load "git_reflow/workflows/core.rb"
     end
 
@@ -118,14 +120,14 @@ module GitReflow
 
 
           Array(callbacks[:before][name]).each do |block|
-            GitReflow.logger.debug "Running [before] callback for `#{name}` command..."
+            GitReflow.logger.debug "(before) callback running for `#{name}` command..."
             block.call(**args_with_defaults)
           end
 
           block.call(**args_with_defaults)
 
           Array(callbacks[:after][name]).each do |block|
-            GitReflow.logger.debug "Running [before] callback for `#{name}` command..."
+            GitReflow.logger.debug "(after) callback running for `#{name}` command..."
             block.call(**args_with_defaults)
           end
         end
@@ -145,7 +147,7 @@ module GitReflow
         if commands[name].nil?
           GitReflow.logger.error "Attempted to register (before) callback for non-existing command: #{name}"
         else
-          GitReflow.logger.debug "Callback (before) registered for: #{name}, #{block}"
+          GitReflow.logger.debug "(before) callback registered for: #{name}"
           callbacks[:before][name] ||= []
           callbacks[:before][name] << block
         end
@@ -165,6 +167,7 @@ module GitReflow
         if commands[name].nil?
           GitReflow.logger.error "Attempted to register (after) callback for non-existing command: #{name}"
         else
+          GitReflow.logger.debug "(after) callback registered for: #{name}"
           callbacks[:after][name] ||= []
           callbacks[:after][name] << block
         end

--- a/spec/lib/git_reflow/git_server/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/pull_request_spec.rb
@@ -496,7 +496,7 @@ describe GitReflow::GitServer::PullRequest do
         it     { should be_truthy }
       end
 
-      context "and user choose not to cleanup" do
+      context "and user chooses not to cleanup" do
         before { expect(pr).to receive(:ask).with('Would you like to push this branch to your remote repo and cleanup your feature branch? ').and_return('no') }
         it     { should be_falsy }
       end

--- a/spec/lib/git_reflow/workflow_spec.rb
+++ b/spec/lib/git_reflow/workflow_spec.rb
@@ -9,6 +9,8 @@ describe GitReflow::Workflow do
   let(:workflow) { DummyWorkflow }
   let(:loader)   { double() }
 
+  before { GitReflow::Workflow.reset! }
+
   describe ".current" do
     subject { GitReflow::Workflow.current }
 

--- a/spec/lib/git_reflow_spec.rb
+++ b/spec/lib/git_reflow_spec.rb
@@ -52,11 +52,14 @@ describe GitReflow do
     end
 
     context "when a workflow is set" do
+      before { GitReflow::Workflow.reset! }
       after { GitReflow::Workflow.reset! }
 
       it "calls the defined workflow methods instead of the default core" do
         workflow_path = File.join(File.expand_path("../../fixtures", __FILE__), "/awesome_workflow.rb")
         allow(GitReflow::Config).to receive(:get).with("reflow.workflow").and_return(workflow_path)
+        expect(GitReflow::Workflows::Core).to receive(:load_workflow).with("#{GitReflow.git_root_dir}/Workflow").once
+        expect(GitReflow::Workflows::Core).to receive(:load_workflow).with(workflow_path).once.and_call_original
 
         expect{ subject.start }.to have_said "Awesome."
       end


### PR DESCRIPTION
Currently the workflow loader is reloading the workflow files multiple times per session, which causes before/after hooks to execute multiple times.  This caches the workflow that is loaded on each "session" (run of a git-reflow command).
