### PR TITLE
Retry pull-request creation if there are errors

### DIFF
--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -38,7 +38,7 @@ module GitReflow
 
         def commit_author
           begin
-            username, branch = base.label.split(':')
+            username, _  = base.label.split(':')
             first_commit = GitReflow.git_server.connection.pull_requests.commits(username, GitReflow.git_server.class.remote_repo_name, number.to_s).first
             "#{first_commit.commit.author.name} <#{first_commit.commit.author.email}>".strip
           rescue Github::Error::NotFound

--- a/spec/fixtures/pull_requests/pull_request_branch_nonexistent_error.json
+++ b/spec/fixtures/pull_requests/pull_request_branch_nonexistent_error.json
@@ -1,0 +1,32 @@
+{
+  :method => :post,
+  :body   => "{
+    \"errors\"     : [{
+      \"code\"     : \"invalid\",
+      \"field\"    : \"head\",
+      \"message\"  : \"head The branch reenhanced:banana does not exist.\",
+      \"resource\" : \"PullRequest\" }],
+    \"message\" : \"Validation Failed\"}",
+  :url => "https://api.github.com/repos/reenhanced/gitreflow/pulls?access_token=12345",
+  :request_headers => {
+    "Content-Type"  => "application/json",
+    "Authorization" => "Token token=\"12345\""
+  },
+  :parallel_manager => nil,
+  :request          => {:proxy => nil},
+  :ssl              => {},
+  :status           => 422,
+  :response_headers => {
+    "server"                  => "nginx/1.0.13",
+    "date"                    => "Fri, 27 Apr 2012 13:02:49 GMT",
+    "content-type"            => "application/json; charset=utf-8",
+    "connection"              => "close",
+    "status"                  => "422 Unprocessable Entity",
+    "x-ratelimit-limit"       => "5000",
+    "etag"                    => "\"ebdeb717fe19444c308e608728569d5a\"",
+    "x-oauth-scopes"          => "repo",
+    "x-ratelimit-remaining"   => "4996",
+    "x-accepted-oauth-scopes" => "repo",
+    "content-length"          => "192"},
+  :response => ""
+}


### PR DESCRIPTION
There is a race-condition when creating a Pull Request on GitHub where the feature branch that was pushed in the previous command may not be completely resolved by GitHub.  This adds a few retries as a means of waiting it out.

Respolves #84
