### PR TITLE
Fixes Github comment matching to exclude PR author

### DIFF
--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -47,7 +47,7 @@ module GitReflow
         end
 
         def reviewers
-          (comment_authors + pull_request_reviews.map(&:user).map(&:login)).uniq
+          (comment_authors + pull_request_reviews.map(&:user).map(&:login)).uniq - [user.login]
         end
 
         def approvals
@@ -65,7 +65,7 @@ module GitReflow
           comments        = GitReflow.git_server.connection.issues.comments.all        GitReflow.remote_user, GitReflow.remote_repo_name, number: self.number
           review_comments = GitReflow.git_server.connection.pull_requests.comments.all GitReflow.remote_user, GitReflow.remote_repo_name, number: self.number
 
-          review_comments.to_a + comments.to_a
+          (review_comments.to_a + comments.to_a).select { |c| c.user.login != user.login }
         end
 
         def last_comment

--- a/lib/git_reflow/git_server/git_hub/pull_request.rb
+++ b/lib/git_reflow/git_server/git_hub/pull_request.rb
@@ -80,7 +80,10 @@ module GitReflow
           if self.class.minimum_approvals.to_i == 0
             super
           else
-            approvals.size >= self.class.minimum_approvals.to_i and !last_comment.match(self.class.approval_regex).nil?
+            approvals.size >= self.class.minimum_approvals.to_i and (
+              last_comment.empty? ||
+              !last_comment.match(self.class.approval_regex).nil?
+            )
           end
         end
 

--- a/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
+++ b/spec/lib/git_reflow/git_server/git_hub/pull_request_spec.rb
@@ -86,15 +86,15 @@ describe GitReflow::GitServer::GitHub::PullRequest do
           pull_request: {
             number: existing_pull_request.number,
             comments: [{author: comment_author}],
-            reviews: []
+            reviews: [{author: existing_pull_request.user.login}]
           },
           issue: {
             number: existing_pull_request.number,
-            comments: [{author: comment_author}]
+            comments: [{author: comment_author}, {author: existing_pull_request.user.login}]
           }
         )
       end
-      specify { expect(subject).to eql(existing_pull_comments.to_a + existing_issue_comments.to_a) }
+      specify { expect(subject).to eql(existing_pull_comments.to_a + existing_issue_comments.to_a - [existing_pull_request.user.login]) }
     end
 
     context "Testing Nil Comments" do
@@ -133,7 +133,7 @@ describe GitReflow::GitServer::GitHub::PullRequest do
           number: existing_pull_request.number,
           owner: existing_pull_request.user.login,
           comments: [{author: 'tito'}, {author: 'bobby'}, {author: 'ringo'}],
-          reviews:  [{author: 'nature-boy'}]
+          reviews:  [{author: 'ringo'}, {author: 'nature-boy'}]
         },
         issue: {
           number: existing_pull_request.number,


### PR DESCRIPTION
Currently, when the author of the PR comments on the PR itself, the validation checks aren't excluding the author's comments in all cases.  This fixes that :smile:
