### PR TITLE
Allows for configuring a custom base-branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This sets up a feature branch remotely and brings a local copy to your machine. 
 
 `git reflow start` takes in the name of the new branch name that you want to create your feature on.
 In addition, it takes in an optional flag of a _base-branch_ name (`--base`). If you don't pass in this parameter,
-then it defaults to "master". The base branch name is the base branch that you want to base your feature off of.
+then it will look up the `reflow.base-branch` git configuration or default to "master". The base branch name is the base branch that you want to base your feature off of.
 This ensures that every time you start a new base branch, it will be based off of your latest remote base.
 
     git reflow start nh-branch-name --base base-branch-name

--- a/README.md
+++ b/README.md
@@ -150,9 +150,11 @@ We assume you know what you're doing, so if you need something different, do it 
 
 After making commits to your branch, run `review`. Didn't push it up? No problem, we'll do it for you.
 ```
-git reflow review -t <title> -m <message>
+git reflow review -t <title> -m <message> <base-branch>
 ```
-> **Note:** `-t` and `-m` are optional.
+> **Note:** `-t` and `-m` are optional, as is the `base-branch` argument. If no
+> base-branch is provided, then we'll look for a `reflow.base-branch` git
+> configuration and fallback to `master` as the default.
 
 If you do not pass the title or message options to the review command, you will be given an editor to write your PR request commit message, similar to `git commit`. The first line is the title, the rest is the body.
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ git reflow refresh -r <remote-location> -b <base-branch>
 
 You pass in the name of the remote to fetch from and the name of the **base-branch** that you would like to merge into your **feature-branch**. The **remote-location** defaults to `origin` and the base-branch defaults to `master`. This command also takes in remote and branch name as flag options.
 
+> **Note:** If no `base-branch` argument is provided, then we'll look for a `reflow.base-branch` git
+> configuration and fallback to `master` as the default.
+
 ### Reviewing your work
 ![git reflow review](http://reenhanced.com/reflow/git-reflow-review.gif)
 ```

--- a/README.md
+++ b/README.md
@@ -204,8 +204,11 @@ If not, create it and print "Pull request created at http://pull-url/". If so, p
 ### Checking your branch status
 ![git reflow status](http://reenhanced.com/reflow/git-reflow-status.gif)
 ```
-git reflow status
+git reflow status <base-branch>
 ```
+
+> **Note:** If no > base-branch is provided, then we'll look for a `reflow.base-branch` git
+> configuration and fallback to `master` as the default.
 
 Sometimes you start working on a branch and can't get back to it for a while. It happens. Use +status+ to check on the status of your work.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ If not, create it and print "Pull request created at http://pull-url/". If so, p
 git reflow status <base-branch>
 ```
 
-> **Note:** If no > base-branch is provided, then we'll look for a `reflow.base-branch` git
+> **Note:** If no `base-branch` is provided, then we'll look for a `reflow.base-branch` git
 > configuration and fallback to `master` as the default.
 
 Sometimes you start working on a branch and can't get back to it for a while. It happens. Use +status+ to check on the status of your work.
@@ -231,10 +231,13 @@ to find out where your pull request is at. But in case you want to take a look, 
 ### Delivering approved code
 ![git-reflow deliver](http://reenhanced.com/reflow/git-reflow-deliver.gif)
 ```
-git reflow deliver
+git reflow deliver <base-branch>
 ```
 
-> **Note:** This documentation is for the process for the github "remote" merge process via the github_api.
+> **Note:** If no `base-branch` argument is provided, then we'll look for a `reflow.base-branch` git
+> configuration and fallback to `master` as the default.
+
+> **Also:** This documentation is for the process for the github "remote" merge process via the github_api.
   For the bitbucket standard or github manual process (used when the user applies -f force flag to the "remote" merge via the github_api), please go to section B.
 
 

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -36,6 +36,12 @@ module GitReflow
       extract_remote_user_and_repo_from_remote_url(GitReflow::Config.get('remote.origin.url'))[:repo]
     end
 
+    def default_base_branch
+      base_branch_name = GitReflow::Config.get('reflow.base-branch')
+      return 'master' if base_branch_name.empty?
+      base_branch_name
+    end
+
     def current_branch
       run("git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'", loud: false).strip
     end

--- a/lib/git_reflow/rspec/workflow_helpers.rb
+++ b/lib/git_reflow/rspec/workflow_helpers.rb
@@ -9,10 +9,9 @@ module GitReflow
       end
 
       def suppress_loading_of_external_workflows
-        allow(File).to receive(:exists?).and_call_original
-        allow(File).to receive(:exists?).with("#{GitReflow.git_root_dir}/Workflow").and_return(false)
+        allow(GitReflow::Workflows::Core).to receive(:load__workflow).with("#{GitReflow.git_root_dir}/Workflow").and_return(false)
         return if GitReflow::Config.get('reflow.workflow').to_s.empty?
-        allow(File).to receive(:exists?).with(GitReflow::Config.get('reflow.workflow')).and_return(false)
+        allow(GitReflow::Workflows::Core).to receive(:load_workflow).with(GitReflow::Config.get('reflow.workflow')).and_return(false)
       end
     end
   end

--- a/lib/git_reflow/sandbox.rb
+++ b/lib/git_reflow/sandbox.rb
@@ -4,6 +4,7 @@ module GitReflow
 
     COLOR_FOR_LABEL = {
       notice:         :yellow,
+      info:           :yellow,
       error:          :red,
       deliver_halted: :red,
       review_halted:  :red,

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -74,12 +74,13 @@ module GitReflow
       # @param [Hash] options the options to run start with
       # @option options [String] :base ("master") the name of the base branch you want to checkout your feature from
       # @option options [String] :feature_branch the name of the base branch you want to checkout your feature from
-      command(:start, arguments: { feature_branch: nil }, flags: { base: "master" }) do |**params|
-        base_branch    = params[:base]
+      command(:start, arguments: { feature_branch: nil }, flags: { base: nil }) do |**params|
+        base_branch    = params[:base] || GitReflow::Config.get("reflow.base-branch")
         feature_branch = params[:feature_branch]
 
         if feature_branch.to_s.strip.empty?
           say "usage: git-reflow start [new-branch-name]", :error
+
         else
           run_command_with_label "git checkout #{base_branch}"
           run_command_with_label "git pull origin #{base_branch}"

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -196,12 +196,13 @@ LONGTIME
       #
       # @param [Hash] options the options to run review with
       # @option options [String] :destination_branch ("master") the branch you're merging your feature into
-      command(:status, arguments: { destination_branch: "master" }) do |**params|
-        pull_request = GitReflow.git_server.find_open_pull_request( :from => GitReflow.current_branch, :to => params[:destination_branch] )
+      command(:status, arguments: { destination_branch: nil }) do |**params|
+        base_branch = params[:destination_branch] || default_base_branch
+        pull_request = GitReflow.git_server.find_open_pull_request( :from => GitReflow.current_branch, :to => base_branch )
 
         if pull_request.nil?
-          say "No pull request exists for #{GitReflow.current_branch} -> #{params[:destination_branch]}", :notice
-          say "Run 'git reflow review #{params[:destination_branch]}' to start the review process", :notice
+          say "No pull request exists for #{GitReflow.current_branch} -> #{base_branch}", :notice
+          say "Run 'git reflow review #{base_branch}' to start the review process", :notice
         else
           say "Here's the status of your review:"
           pull_request.display_pull_request_summary

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << File.expand_path(File.realpath(__dir__) + '/../..')
+$: << File.expand_path(File.dirname(File.realpath(__FILE__)) + '/../..')
 require 'git_reflow/workflow'
 
 module GitReflow
@@ -6,14 +6,14 @@ module GitReflow
     # This class contains the core workflow for git-reflow. Going forward, this
     # will act as the base class for customizing and extending git-reflow.
     class Core
-      include ::GitReflow::Workflow
+      include GitReflow::Workflow
 
       # Reads and evaluates the provided file  in the context of this class
       #
       # @param workflow_path [String] the path of the Workflow file to eval
       def self.load_workflow(workflow_path)
         return unless workflow_path.length > 0 and File.exists?(workflow_path)
-        ::GitReflow.logger.debug "Using workflow: #{workflow_path}"
+        GitReflow.logger.debug "Using workflow: #{workflow_path}"
         self.load_raw_workflow(File.read(workflow_path))
       end
 
@@ -21,8 +21,7 @@ module GitReflow
       #
       # @param workflow_string [String] the contents of a Workflow file to eval
       def self.load_raw_workflow(workflow_string)
-        return if workflow_string.strip.empty?
-        ::GitReflow.logger.debug "Evaluating workflow..."
+        GitReflow.logger.debug "Evaluating workflow..."
         binding.eval(workflow_string)
       end
 
@@ -33,31 +32,31 @@ module GitReflow
       # @option options [Boolean] :enterprise (false) whether to configure git-reflow for use with Github Enterprise
       command(:setup, switches: { local: false, enterprise: false}) do |**params|
         reflow_options             = { project_only: params[:local], enterprise: params[:enterprise] }
-        existing_git_include_paths = git_config.get('include.path', all: true).split("\n")
+        existing_git_include_paths = GitReflow::Config.get('include.path', all: true).split("\n")
 
-        unless File.exist?(git_config::CONFIG_FILE_PATH) or existing_git_include_paths.include?(git_config::CONFIG_FILE_PATH)
-          say "We'll walk you through setting up git-reflow's defaults for all your projects.", :notice
-          say "In the future, you can run \`git-reflow setup --local\` from the root of any project you want to setup differently.", :notice
-          run "touch #{git_config::CONFIG_FILE_PATH}"
-          say "Created #{git_config::CONFIG_FILE_PATH} for git-reflow specific configurations.", :notice
-          git_config.add "include.path", git_config::CONFIG_FILE_PATH, global: true
-          say "Added #{git_config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
+        unless File.exist?(GitReflow::Config::CONFIG_FILE_PATH) or existing_git_include_paths.include?(GitReflow::Config::CONFIG_FILE_PATH)
+          GitReflow.say "We'll walk you through setting up git-reflow's defaults for all your projects.", :notice
+          GitReflow.say "In the future, you can run \`git-reflow setup --local\` from the root of any project you want to setup differently.", :notice
+          GitReflow.run "touch #{GitReflow::Config::CONFIG_FILE_PATH}"
+          GitReflow.say "Created #{GitReflow::Config::CONFIG_FILE_PATH} for git-reflow specific configurations.", :notice
+          GitReflow::Config.add "include.path", GitReflow::Config::CONFIG_FILE_PATH, global: true
+          GitReflow.say "Added #{GitReflow::Config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
         end
 
         choose do |menu|
           menu.header = "Available remote Git Server services"
           menu.prompt = "Which service would you like to use for this project?  "
 
-          menu.choice('GitHub')    { ::GitReflow::GitServer.connect reflow_options.merge({ provider: 'GitHub', silent: false }) }
-          menu.choice('BitBucket (team-owned repos only)') { ::GitReflow::GitServer.connect reflow_options.merge({ provider: 'BitBucket', silent: false }) }
+          menu.choice('GitHub')    { GitReflow::GitServer.connect reflow_options.merge({ provider: 'GitHub', silent: false }) }
+          menu.choice('BitBucket (team-owned repos only)') { GitReflow::GitServer.connect reflow_options.merge({ provider: 'BitBucket', silent: false }) }
         end
 
-        git_config.set "constants.minimumApprovals", ask("Set the minimum number of approvals (leaving blank will require approval from all commenters): "), local: reflow_options[:project_only]
-        git_config.set "constants.approvalRegex", ::GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX, local: reflow_options[:project_only]
+        GitReflow::Config.set "constants.minimumApprovals", ask("Set the minimum number of approvals (leaving blank will require approval from all commenters): "), local: reflow_options[:project_only]
+        GitReflow::Config.set "constants.approvalRegex", GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX, local: reflow_options[:project_only]
 
-        if git_config.get('core.editor').length <= 0
-          git_config.set('core.editor', default_editor, local: reflow_options[:project_only])
-          say "Updated git's editor (via git config key 'core.editor') to: #{default_editor}.", :notice
+        if GitReflow::Config.get('core.editor').length <= 0
+          GitReflow::Config.set('core.editor', GitReflow.default_editor, local: reflow_options[:project_only])
+          GitReflow.say "Updated git's editor (via git config key 'core.editor') to: #{GitReflow.default_editor}.", :notice
         end
       end
       command_help(
@@ -75,17 +74,16 @@ module GitReflow
       # @option options [String] :base ("master") the name of the base branch you want to checkout your feature from
       # @option options [String] :feature_branch the name of the base branch you want to checkout your feature from
       command(:start, arguments: { feature_branch: nil }, flags: { base: nil }) do |**params|
-        base_branch    = params[:base] || GitReflow::Config.get("reflow.base-branch")
+        base_branch    = params[:base] || default_base_branch
         feature_branch = params[:feature_branch]
 
-        if feature_branch.to_s.strip.empty?
-          say "usage: git-reflow start [new-branch-name]", :error
-
+        if feature_branch.nil? or feature_branch.length <= 0
+          GitReflow.say "usage: git-reflow start [new-branch-name]", :error
         else
-          run_command_with_label "git checkout #{base_branch}"
-          run_command_with_label "git pull origin #{base_branch}"
-          run_command_with_label "git push origin #{base_branch}:refs/heads/#{feature_branch}"
-          run_command_with_label "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
+          GitReflow.run_command_with_label "git checkout #{base_branch}"
+          GitReflow.run_command_with_label "git pull origin #{base_branch}"
+          GitReflow.run_command_with_label "git push origin #{base_branch}:refs/heads/#{feature_branch}"
+          GitReflow.run_command_with_label "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
         end
       end
       command_help(
@@ -105,36 +103,36 @@ LONGTIME
       # Submit a feature branch for review
       #
       # @param [Hash] options the options to run review with
-      # @option options [String] :base ("master") the name of the base branch you want to merge your feature into
+      # @option options [String] :base (GitReflow::Config.get('reflow.base-branch') or "master") the name of the base branch you want to merge your feature into
       # @option options [String] :title (<current-branch-name>) the title of your pull request
       # @option options [String] :message ("") the body of your pull request
-      command(:review, arguments: { base: "master" }, flags: { title: nil, message: nil }) do |**params|
-        base_branch         = params[:base]
+      command(:review, arguments: { base: nil }, flags: { title: nil, message: nil }) do |**params|
+        base_branch         = params[:base] || default_base_branch
         create_pull_request = true
 
-        fetch_destination base_branch
+        GitReflow.fetch_destination base_branch
         begin
-          push_current_branch
+          GitReflow.push_current_branch
 
-          existing_pull_request = git_server.find_open_pull_request( from: current_branch, to: base_branch )
+          existing_pull_request = GitReflow.git_server.find_open_pull_request( from: GitReflow.current_branch, to: base_branch )
           if existing_pull_request
             say "A pull request already exists for these branches:", :notice
             existing_pull_request.display_pull_request_summary
           else
             unless params[:title] || params[:message]
-              pull_request_msg_file = "#{git_root_dir}/.git/GIT_REFLOW_PR_MSG"
+              pull_request_msg_file = "#{GitReflow.git_root_dir}/.git/GIT_REFLOW_PR_MSG"
 
               File.open(pull_request_msg_file, 'w') do |file|
                 begin
-                  pr_message = params[:title] || pull_request_template || current_branch
+                  pr_message = params[:title] || GitReflow.pull_request_template || GitReflow.current_branch
                   file.write(pr_message)
                 rescue StandardError => e
-                  logger.error "Unable to parse PR template (#{pull_request_msg_file}): #{e.inspect}"
-                  file.write(params[:title] || current_branch)
+                  GitReflow.logger.error "Unable to parse PR template (#{pull_request_msg_file}): #{e.inspect}"
+                  file.write(params[:title] || GitReflow.current_branch)
                 end
               end
 
-              run("#{git_editor_command} #{pull_request_msg_file}", with_system: true)
+              GitReflow.run("#{GitReflow.git_editor_command} #{pull_request_msg_file}", with_system: true)
 
               pr_msg = File.read(pull_request_msg_file).split(/[\r\n]|\r\n/).map(&:strip)
               title  = pr_msg.shift
@@ -160,11 +158,11 @@ LONGTIME
             if create_pull_request
               begin
                 retries ||= 0
-                pull_request = git_server.create_pull_request(
+                pull_request = GitReflow.git_server.create_pull_request(
                   title: params[:title] || params[:message],
                   body:  params[:message],
-                  head:  "#{remote_user}:#{current_branch}",
-                  base:  params[:base]
+                  head:  "#{GitReflow.remote_user}:#{GitReflow.current_branch}",
+                  base:  base_branch
                 )
               rescue Github::Error::UnprocessableEntity
                 retry if (retries += 1) < 3
@@ -199,10 +197,10 @@ LONGTIME
       # @param [Hash] options the options to run review with
       # @option options [String] :destination_branch ("master") the branch you're merging your feature into
       command(:status, arguments: { destination_branch: "master" }) do |**params|
-        pull_request = git_server.find_open_pull_request( :from => current_branch, :to => params[:destination_branch] )
+        pull_request = GitReflow.git_server.find_open_pull_request( :from => GitReflow.current_branch, :to => params[:destination_branch] )
 
         if pull_request.nil?
-          say "No pull request exists for #{current_branch} -> #{params[:destination_branch]}", :notice
+          say "No pull request exists for #{GitReflow.current_branch} -> #{params[:destination_branch]}", :notice
           say "Run 'git reflow review #{params[:destination_branch]}' to start the review process", :notice
         else
           say "Here's the status of your review:"
@@ -223,7 +221,7 @@ LONGTIME
       # @option options [String] :destination_server ("default") the environment server to deploy to (pulled from `git config "reflow.deploy-to-#{destination_server}-command")
       command(:deploy, arguments: { destination_server: "default" }) do |**params|
         destination_server = params[:destination_server] || "default"
-        deploy_command = git_config.get("reflow.deploy-to-#{destination_server}-command", local: true)
+        deploy_command = GitReflow::Config.get("reflow.deploy-to-#{destination_server}-command", local: true)
 
         # first check is to allow for automated setup
         if deploy_command.empty?
@@ -235,7 +233,7 @@ LONGTIME
           say "Skipping deployment..."
           false
         else
-          git_config.set("reflow.deploy-to-#{destination_server}-command", deploy_command, local: true)
+          GitReflow::Config.set("reflow.deploy-to-#{destination_server}-command", deploy_command, local: true)
           run_command_with_label(deploy_command, with_system: true)
         end
       end
@@ -249,30 +247,30 @@ LONGTIME
 
       # Merge and deploy a feature branch to a staging branch
       command(:stage) do |**params|
-        feature_branch_name = current_branch
-        staging_branch_name = git_config.get('reflow.staging-branch', local: true)
+        feature_branch_name = GitReflow.current_branch
+        staging_branch_name = GitReflow::Config.get('reflow.staging-branch', local: true)
 
         if staging_branch_name.empty?
-          staging_branch_name = ask("What's the name of your staging branch? (default: 'staging') ")
+          staging_branch_name = GitReflow.ask("What's the name of your staging branch? (default: 'staging') ")
           staging_branch_name = 'staging' if staging_branch_name.strip == ''
-          git_config.set('reflow.staging-branch', staging_branch_name, local: true)
+          GitReflow::Config.set('reflow.staging-branch', staging_branch_name, local: true)
         end
 
-        run_command_with_label "git checkout #{staging_branch_name}"
-        run_command_with_label "git pull origin #{staging_branch_name}"
+        GitReflow.run_command_with_label "git checkout #{staging_branch_name}"
+        GitReflow.run_command_with_label "git pull origin #{staging_branch_name}"
 
-        if run_command_with_label "git merge #{feature_branch_name}", with_system: true
-          run_command_with_label "git push origin #{staging_branch_name}"
+        if GitReflow.run_command_with_label "git merge #{feature_branch_name}", with_system: true
+          GitReflow.run_command_with_label "git push origin #{staging_branch_name}"
 
           staged = self.deploy(destination_server: :staging)
 
           if staged
-            say "Deployed to Staging.", :success
+            GitReflow.say "Deployed to Staging.", :success
           else
-            say "There were issues deploying to staging.", :error
+            GitReflow.say "There were issues deploying to staging.", :error
           end
         else
-          say "There were issues merging your feature branch to staging.", :error
+          GitReflow.say "There were issues merging your feature branch to staging.", :error
         end
       end
       command_help(
@@ -288,10 +286,10 @@ LONGTIME
       command(:deliver, arguments: { base: "master" }, flags: { merge_method: "squash" }, switches: { force: false, skip_lgtm: false }) do |**params|
         params[:force] = params[:force] || params[:skip_lgtm]
         begin
-          existing_pull_request = git_server.find_open_pull_request( from: current_branch, to: params[:base] )
+          existing_pull_request = GitReflow.git_server.find_open_pull_request( from: GitReflow.current_branch, to: params[:base] )
 
           if existing_pull_request.nil?
-            say "No pull request exists for #{remote_user}:#{current_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted
+            say "No pull request exists for #{GitReflow.remote_user}:#{GitReflow.current_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted
           else
 
             if existing_pull_request.good_to_merge?(force: params[:force])
@@ -338,7 +336,7 @@ LONGTIME
       # @option options [String] :remote ("origin") the name of the remote repository to fetch updates from
       # @option options [String] :base ("master") the branch that you want to fetch updates from
       command(:refresh, flags: { remote: 'origin', base: 'master'}) do |**params|
-        update_feature_branch(params)
+        GitReflow.update_feature_branch(params)
       end
       command_help(
         :refresh,

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -1,4 +1,4 @@
-$: << File.expand_path(File.dirname(File.realpath(__FILE__)) + '/../..')
+$LOAD_PATH << File.expand_path(File.realpath(__dir__) + '/../..')
 require 'git_reflow/workflow'
 
 module GitReflow
@@ -6,14 +6,14 @@ module GitReflow
     # This class contains the core workflow for git-reflow. Going forward, this
     # will act as the base class for customizing and extending git-reflow.
     class Core
-      include GitReflow::Workflow
+      include ::GitReflow::Workflow
 
       # Reads and evaluates the provided file  in the context of this class
       #
       # @param workflow_path [String] the path of the Workflow file to eval
       def self.load_workflow(workflow_path)
         return unless workflow_path.length > 0 and File.exists?(workflow_path)
-        GitReflow.logger.debug "Using workflow: #{workflow_path}"
+        ::GitReflow.logger.debug "Using workflow: #{workflow_path}"
         self.load_raw_workflow(File.read(workflow_path))
       end
 
@@ -21,7 +21,8 @@ module GitReflow
       #
       # @param workflow_string [String] the contents of a Workflow file to eval
       def self.load_raw_workflow(workflow_string)
-        GitReflow.logger.debug "Evaluating workflow..."
+        return if workflow_string.strip.empty?
+        ::GitReflow.logger.debug "Evaluating workflow..."
         binding.eval(workflow_string)
       end
 
@@ -32,31 +33,31 @@ module GitReflow
       # @option options [Boolean] :enterprise (false) whether to configure git-reflow for use with Github Enterprise
       command(:setup, switches: { local: false, enterprise: false}) do |**params|
         reflow_options             = { project_only: params[:local], enterprise: params[:enterprise] }
-        existing_git_include_paths = GitReflow::Config.get('include.path', all: true).split("\n")
+        existing_git_include_paths = git_config.get('include.path', all: true).split("\n")
 
-        unless File.exist?(GitReflow::Config::CONFIG_FILE_PATH) or existing_git_include_paths.include?(GitReflow::Config::CONFIG_FILE_PATH)
-          GitReflow.say "We'll walk you through setting up git-reflow's defaults for all your projects.", :notice
-          GitReflow.say "In the future, you can run \`git-reflow setup --local\` from the root of any project you want to setup differently.", :notice
-          GitReflow.run "touch #{GitReflow::Config::CONFIG_FILE_PATH}"
-          GitReflow.say "Created #{GitReflow::Config::CONFIG_FILE_PATH} for git-reflow specific configurations.", :notice
-          GitReflow::Config.add "include.path", GitReflow::Config::CONFIG_FILE_PATH, global: true
-          GitReflow.say "Added #{GitReflow::Config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
+        unless File.exist?(git_config::CONFIG_FILE_PATH) or existing_git_include_paths.include?(git_config::CONFIG_FILE_PATH)
+          say "We'll walk you through setting up git-reflow's defaults for all your projects.", :notice
+          say "In the future, you can run \`git-reflow setup --local\` from the root of any project you want to setup differently.", :notice
+          run "touch #{git_config::CONFIG_FILE_PATH}"
+          say "Created #{git_config::CONFIG_FILE_PATH} for git-reflow specific configurations.", :notice
+          git_config.add "include.path", git_config::CONFIG_FILE_PATH, global: true
+          say "Added #{git_config::CONFIG_FILE_PATH} to include.path in $HOME/.gitconfig.", :notice
         end
 
         choose do |menu|
           menu.header = "Available remote Git Server services"
           menu.prompt = "Which service would you like to use for this project?  "
 
-          menu.choice('GitHub')    { GitReflow::GitServer.connect reflow_options.merge({ provider: 'GitHub', silent: false }) }
-          menu.choice('BitBucket (team-owned repos only)') { GitReflow::GitServer.connect reflow_options.merge({ provider: 'BitBucket', silent: false }) }
+          menu.choice('GitHub')    { ::GitReflow::GitServer.connect reflow_options.merge({ provider: 'GitHub', silent: false }) }
+          menu.choice('BitBucket (team-owned repos only)') { ::GitReflow::GitServer.connect reflow_options.merge({ provider: 'BitBucket', silent: false }) }
         end
 
-        GitReflow::Config.set "constants.minimumApprovals", ask("Set the minimum number of approvals (leaving blank will require approval from all commenters): "), local: reflow_options[:project_only]
-        GitReflow::Config.set "constants.approvalRegex", GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX, local: reflow_options[:project_only]
+        git_config.set "constants.minimumApprovals", ask("Set the minimum number of approvals (leaving blank will require approval from all commenters): "), local: reflow_options[:project_only]
+        git_config.set "constants.approvalRegex", ::GitReflow::GitServer::PullRequest::DEFAULT_APPROVAL_REGEX, local: reflow_options[:project_only]
 
-        if GitReflow::Config.get('core.editor').length <= 0
-          GitReflow::Config.set('core.editor', GitReflow.default_editor, local: reflow_options[:project_only])
-          GitReflow.say "Updated git's editor (via git config key 'core.editor') to: #{GitReflow.default_editor}.", :notice
+        if git_config.get('core.editor').length <= 0
+          git_config.set('core.editor', default_editor, local: reflow_options[:project_only])
+          say "Updated git's editor (via git config key 'core.editor') to: #{default_editor}.", :notice
         end
       end
       command_help(
@@ -78,12 +79,12 @@ module GitReflow
         feature_branch = params[:feature_branch]
 
         if feature_branch.nil? or feature_branch.length <= 0
-          GitReflow.say "usage: git-reflow start [new-branch-name]", :error
+          say "usage: git-reflow start [new-branch-name]", :error
         else
-          GitReflow.run_command_with_label "git checkout #{base_branch}"
-          GitReflow.run_command_with_label "git pull origin #{base_branch}"
-          GitReflow.run_command_with_label "git push origin #{base_branch}:refs/heads/#{feature_branch}"
-          GitReflow.run_command_with_label "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
+          run_command_with_label "git checkout #{base_branch}"
+          run_command_with_label "git pull origin #{base_branch}"
+          run_command_with_label "git push origin #{base_branch}:refs/heads/#{feature_branch}"
+          run_command_with_label "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
         end
       end
       command_help(
@@ -110,29 +111,29 @@ LONGTIME
         base_branch         = params[:base] || default_base_branch
         create_pull_request = true
 
-        GitReflow.fetch_destination base_branch
+        fetch_destination base_branch
         begin
-          GitReflow.push_current_branch
+          push_current_branch
 
-          existing_pull_request = GitReflow.git_server.find_open_pull_request( from: GitReflow.current_branch, to: base_branch )
+          existing_pull_request = git_server.find_open_pull_request( from: current_branch, to: base_branch )
           if existing_pull_request
             say "A pull request already exists for these branches:", :notice
             existing_pull_request.display_pull_request_summary
           else
             unless params[:title] || params[:message]
-              pull_request_msg_file = "#{GitReflow.git_root_dir}/.git/GIT_REFLOW_PR_MSG"
+              pull_request_msg_file = "#{git_root_dir}/.git/GIT_REFLOW_PR_MSG"
 
               File.open(pull_request_msg_file, 'w') do |file|
                 begin
-                  pr_message = params[:title] || GitReflow.pull_request_template || GitReflow.current_branch
+                  pr_message = params[:title] || pull_request_template || current_branch
                   file.write(pr_message)
                 rescue StandardError => e
-                  GitReflow.logger.error "Unable to parse PR template (#{pull_request_msg_file}): #{e.inspect}"
-                  file.write(params[:title] || GitReflow.current_branch)
+                  logger.error "Unable to parse PR template (#{pull_request_msg_file}): #{e.inspect}"
+                  file.write(params[:title] || current_branch)
                 end
               end
 
-              GitReflow.run("#{GitReflow.git_editor_command} #{pull_request_msg_file}", with_system: true)
+              run("#{git_editor_command} #{pull_request_msg_file}", with_system: true)
 
               pr_msg = File.read(pull_request_msg_file).split(/[\r\n]|\r\n/).map(&:strip)
               title  = pr_msg.shift
@@ -158,10 +159,10 @@ LONGTIME
             if create_pull_request
               begin
                 retries ||= 0
-                pull_request = GitReflow.git_server.create_pull_request(
+                pull_request = git_server.create_pull_request(
                   title: params[:title] || params[:message],
                   body:  params[:message],
-                  head:  "#{GitReflow.remote_user}:#{GitReflow.current_branch}",
+                  head:  "#{remote_user}:#{current_branch}",
                   base:  base_branch
                 )
               rescue Github::Error::UnprocessableEntity
@@ -198,10 +199,10 @@ LONGTIME
       # @option options [String] :destination_branch ("master") the branch you're merging your feature into
       command(:status, arguments: { destination_branch: nil }) do |**params|
         base_branch = params[:destination_branch] || default_base_branch
-        pull_request = GitReflow.git_server.find_open_pull_request( :from => GitReflow.current_branch, :to => base_branch )
+        pull_request = git_server.find_open_pull_request( :from => current_branch, :to => base_branch )
 
         if pull_request.nil?
-          say "No pull request exists for #{GitReflow.current_branch} -> #{base_branch}", :notice
+          say "No pull request exists for #{current_branch} -> #{base_branch}", :notice
           say "Run 'git reflow review #{base_branch}' to start the review process", :notice
         else
           say "Here's the status of your review:"
@@ -222,7 +223,7 @@ LONGTIME
       # @option options [String] :destination_server ("default") the environment server to deploy to (pulled from `git config "reflow.deploy-to-#{destination_server}-command")
       command(:deploy, arguments: { destination_server: "default" }) do |**params|
         destination_server = params[:destination_server] || "default"
-        deploy_command = GitReflow::Config.get("reflow.deploy-to-#{destination_server}-command", local: true)
+        deploy_command = git_config.get("reflow.deploy-to-#{destination_server}-command", local: true)
 
         # first check is to allow for automated setup
         if deploy_command.empty?
@@ -234,7 +235,7 @@ LONGTIME
           say "Skipping deployment..."
           false
         else
-          GitReflow::Config.set("reflow.deploy-to-#{destination_server}-command", deploy_command, local: true)
+          git_config.set("reflow.deploy-to-#{destination_server}-command", deploy_command, local: true)
           run_command_with_label(deploy_command, with_system: true)
         end
       end
@@ -248,30 +249,30 @@ LONGTIME
 
       # Merge and deploy a feature branch to a staging branch
       command(:stage) do |**params|
-        feature_branch_name = GitReflow.current_branch
-        staging_branch_name = GitReflow::Config.get('reflow.staging-branch', local: true)
+        feature_branch_name = current_branch
+        staging_branch_name = git_config.get('reflow.staging-branch', local: true)
 
         if staging_branch_name.empty?
-          staging_branch_name = GitReflow.ask("What's the name of your staging branch? (default: 'staging') ")
+          staging_branch_name = ask("What's the name of your staging branch? (default: 'staging') ")
           staging_branch_name = 'staging' if staging_branch_name.strip == ''
-          GitReflow::Config.set('reflow.staging-branch', staging_branch_name, local: true)
+          git_config.set('reflow.staging-branch', staging_branch_name, local: true)
         end
 
-        GitReflow.run_command_with_label "git checkout #{staging_branch_name}"
-        GitReflow.run_command_with_label "git pull origin #{staging_branch_name}"
+        run_command_with_label "git checkout #{staging_branch_name}"
+        run_command_with_label "git pull origin #{staging_branch_name}"
 
-        if GitReflow.run_command_with_label "git merge #{feature_branch_name}", with_system: true
-          GitReflow.run_command_with_label "git push origin #{staging_branch_name}"
+        if run_command_with_label "git merge #{feature_branch_name}", with_system: true
+          run_command_with_label "git push origin #{staging_branch_name}"
 
           staged = self.deploy(destination_server: :staging)
 
           if staged
-            GitReflow.say "Deployed to Staging.", :success
+            say "Deployed to Staging.", :success
           else
-            GitReflow.say "There were issues deploying to staging.", :error
+            say "There were issues deploying to staging.", :error
           end
         else
-          GitReflow.say "There were issues merging your feature branch to staging.", :error
+          say "There were issues merging your feature branch to staging.", :error
         end
       end
       command_help(
@@ -289,10 +290,10 @@ LONGTIME
         params[:base] ||= default_base_branch
 
         begin
-          existing_pull_request = GitReflow.git_server.find_open_pull_request( from: GitReflow.current_branch, to: params[:base] )
+          existing_pull_request = git_server.find_open_pull_request( from: current_branch, to: params[:base] )
 
           if existing_pull_request.nil?
-            say "No pull request exists for #{GitReflow.remote_user}:#{GitReflow.current_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted
+            say "No pull request exists for #{remote_user}:#{current_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted
           else
 
             if existing_pull_request.good_to_merge?(force: params[:force])
@@ -338,8 +339,9 @@ LONGTIME
       # @param [Hash] options the options to run review with
       # @option options [String] :remote ("origin") the name of the remote repository to fetch updates from
       # @option options [String] :base ("master") the branch that you want to fetch updates from
-      command(:refresh, flags: { remote: 'origin', base: 'master'}) do |**params|
-        GitReflow.update_feature_branch(params)
+      command(:refresh, flags: { remote: 'origin', base: nil}) do |**params|
+        params[:base] ||= default_base_branch
+        update_feature_branch(params)
       end
       command_help(
         :refresh,

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -284,8 +284,10 @@ LONGTIME
       # @param [Hash] options the options to run review with
       # @option options [String] :base ("master") the base branch to merge your feature branch into
       # @option options [String] :force (false) whether to force-deliver the feature branch, ignoring any QA checks
-      command(:deliver, arguments: { base: "master" }, flags: { merge_method: "squash" }, switches: { force: false, skip_lgtm: false }) do |**params|
+      command(:deliver, arguments: { base: nil }, flags: { merge_method: "squash" }, switches: { force: false, skip_lgtm: false }) do |**params|
         params[:force] = params[:force] || params[:skip_lgtm]
+        params[:base] ||= default_base_branch
+
         begin
           existing_pull_request = GitReflow.git_server.find_open_pull_request( from: GitReflow.current_branch, to: params[:base] )
 

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -82,6 +82,16 @@ describe GitReflow::GitHelpers do
     end
   end
 
+  describe '.default_base_branch' do
+    subject { Gitacular.default_base_branch }
+    it      { is_expected.to eq('master') }
+
+    context 'when configured' do
+      before { allow(GitReflow::Config).to receive(:get).with('reflow.base-branch').and_return('tuba') }
+      it { is_expected.to eq('tuba') }
+    end
+  end
+
   describe ".current_branch" do
     subject { Gitacular.current_branch }
     it      { expect{ subject }.to have_run_command_silently "git branch --no-color | grep '^\* ' | grep -v 'no branch' | sed 's/^* //g'" }

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -452,6 +452,18 @@ describe GitReflow::Workflows::Core do
           subject
         end
       end
+
+      context "when custom base-branch is configured" do
+        before do
+          allow(GitReflow::Config).to receive(:get).and_call_original
+          allow(GitReflow::Config).to receive(:get).with('reflow.base-branch').and_return('racecar')
+        end
+        subject { workflow.status }
+        it "uses the custom configured base-branch to lookup the pull request" do
+          expect(GitReflow.git_server).to receive(:find_open_pull_request).with({from: feature_branch, to: 'racecar'}).and_return(existing_gh_pull_request)
+          subject
+        end
+      end
     end
   end
 

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -740,6 +740,37 @@ describe GitReflow::Workflows::Core do
           subject
         end
       end
+
+      context "when a custom base-branch is configured" do
+        subject { workflow.deliver }
+        before do
+          expect(GitReflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'racecar').and_return(existing_gh_pull_request)
+          allow(existing_gh_pull_request).to receive(:good_to_merge?).and_return(true)
+          allow(GitReflow::Config).to receive(:get).with('reflow.base-branch').and_return('racecar')
+        end
+
+
+        it "displays the status of the PR" do
+          allow(existing_gh_pull_request).to receive(:merge!).with(
+            base: 'racecar',
+            merge_method: "squash",
+            force: false,
+            skip_lgtm: false
+          )
+          expect(GitReflow::Workflows::Core).to receive(:status).with(destination_branch: 'racecar')
+          subject
+        end
+
+        it "merges the feature branch" do
+          expect(existing_gh_pull_request).to receive(:merge!).with(
+            base: "racecar",
+            merge_method: "squash",
+            force: false,
+            skip_lgtm: false
+          )
+          subject
+        end
+      end
     end
   end
 

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -5,14 +5,10 @@ describe GitReflow::Workflows::Core do
   let(:existing_pull_requests)    { Fixture.new('pull_requests/pull_requests.json').to_json_hashie }
   let(:existing_gh_pull_request)  { GitReflow::GitServer::GitHub::PullRequest.new existing_pull_requests.first }
   let(:pull_request_message_file) { "#{GitReflow.git_root_dir}/.git/GIT_REFLOW_PR_MSG" }
-  let(:workflow) do
-    class CoreWorkflow < GitReflow::Workflows::Core
-    end
-    CoreWorkflow
-  end
+  let(:workflow)                  { described_class }
 
   before do
-    allow(GitReflow).to receive(:current_branch).and_return(feature_branch)
+    allow(workflow).to receive(:current_branch).and_return(feature_branch)
     allow_any_instance_of(HighLine).to receive(:choose)
   end
 
@@ -20,23 +16,25 @@ describe GitReflow::Workflows::Core do
     let(:workflow_path) { "/tmp/Workflow" }
     subject { GitReflow::Workflows::Core.load_workflow(workflow_path) }
 
+    before { allow(GitReflow::Workflows::Core).to receive(:load_workflow).and_call_original }
+
     it "returns `nil` if the workflow path doesn't exist" do
       allow(File).to receive(:exists?).and_return(false)
       expect(subject).to be_nil
     end
 
     it "evaluates the workflow file in the context of the class" do
-      allow(File).to receive(:exists?).and_return(true)
-      fake_binding = instance_double(Binding)
       workflow_content = "# testing"
+      allow(File).to receive(:exists?).with("#{GitReflow.git_root_dir}/Workflow").and_return(false)
+      allow(File).to receive(:exists?).with(workflow_path).and_return(true)
       expect(File).to receive(:read).with(workflow_path).and_return(workflow_content)
-      expect(described_class).to receive(:binding).and_return(fake_binding)
-      expect(fake_binding).to receive(:eval).with(workflow_content)
+      expect(GitReflow::Workflows::Core).to receive(:load_raw_workflow).with(workflow_content)
       subject
     end
   end
 
   describe ".load_raw_workflow(workflow_string)" do
+    before { allow(GitReflow::Workflows::Core).to receive(:load_workflow).and_call_original }
     it "evaluates the raw string in the context of the Core workflow" do
       workflow_content = <<~WORKFLOW_CONTENT
         command :dummy do
@@ -66,7 +64,8 @@ describe GitReflow::Workflows::Core do
     context "core.editor git config has already been set" do
       before  do
         allow(GitReflow::Config).to receive(:get) { "" }
-        allow(GitReflow::Config).to receive(:get).with('core.editor').and_return('emacs')
+        allow(workflow.git_config).to receive(:get) { "" }
+        allow(workflow.git_config).to receive(:get).with('core.editor').and_return('emacs')
       end
 
       specify { expect { subject }.to_not have_run_command_silently "git config -f #{GitReflow::Config::CONFIG_FILE_PATH} --replace-all core.editor \"#{GitReflow.default_editor}\"", blocking: false }
@@ -124,7 +123,7 @@ describe GitReflow::Workflows::Core do
     let(:feature_branch) { 'new_feature' }
     subject              { workflow.start feature_branch: feature_branch }
 
-    it "updates the local repo and starts creates a new branch" do
+    it "updates the local repo and creates a new branch" do
       expect { subject }.to have_run_commands_in_order [
         "git checkout master",
         "git pull origin master",
@@ -173,11 +172,11 @@ describe GitReflow::Workflows::Core do
     let(:inputs)         { {} }
 
     before do
-      allow(GitReflow).to receive(:remote_user).and_return(user)
+      allow(workflow).to receive(:remote_user).and_return(user)
       allow(GitReflow).to receive(:git_server).and_return(GitReflow::GitServer)
-      allow(GitReflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
-      allow(GitReflow.git_server).to receive(:find_open_pull_request).and_return(nil)
-      allow(GitReflow.git_server).to receive(:create_pull_request).and_return(existing_gh_pull_request)
+      allow(workflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
+      allow(workflow.git_server).to receive(:find_open_pull_request).and_return(nil)
+      allow(workflow.git_server).to receive(:create_pull_request).and_return(existing_gh_pull_request)
       allow(File).to receive(:open).with(pull_request_message_file, 'w')
       allow(File).to receive(:read).with(pull_request_message_file).and_return("bingo")
       allow(File).to receive(:delete)
@@ -200,7 +199,7 @@ describe GitReflow::Workflows::Core do
     it "uses the current branch name as the text for the PR" do
       fake_file = double
       expect(File).to receive(:open).with(pull_request_message_file, "w").and_yield(fake_file)
-      expect(fake_file).to receive(:write).with(GitReflow.current_branch)
+      expect(fake_file).to receive(:write).with(workflow.current_branch)
       subject
     end
 
@@ -224,7 +223,7 @@ describe GitReflow::Workflows::Core do
     context "and a PR template exists" do
       let(:template_content) { "hey now" }
       before do
-        allow(GitReflow).to receive(:pull_request_template).and_return(template_content)
+        allow(workflow).to receive(:pull_request_template).and_return(template_content)
       end
 
       it "uses the template's content for the PR" do
@@ -245,7 +244,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "creates a pull request using the custom base branch" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).with({
+        expect(workflow.git_server).to receive(:create_pull_request).with({
           title: 'bingo',
           body: "\n",
           head: "#{user}:#{feature_branch}",
@@ -284,7 +283,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "creates a pull request with only the given title" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).with({
+        expect(workflow.git_server).to receive(:create_pull_request).with({
           title: inputs[:title],
           body: nil,
           head: "#{user}:#{feature_branch}",
@@ -311,7 +310,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "creates a pull request with the body as both title and body" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).with({
+        expect(workflow.git_server).to receive(:create_pull_request).with({
           title: inputs[:message],
           body: inputs[:message],
           head: "#{user}:#{feature_branch}",
@@ -331,7 +330,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "creates a pull request with only the given title" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).with({
+        expect(workflow.git_server).to receive(:create_pull_request).with({
           title: inputs[:title],
           body: inputs[:message],
           head: "#{user}:#{feature_branch}",
@@ -343,7 +342,7 @@ describe GitReflow::Workflows::Core do
 
     context "with existing pull request" do
       before do
-        expect(GitReflow.git_server).to receive(:find_open_pull_request).and_return(existing_gh_pull_request)
+        expect(workflow.git_server).to receive(:find_open_pull_request).and_return(existing_gh_pull_request)
         allow(existing_gh_pull_request).to receive(:display_pull_request_summary)
       end
 
@@ -363,7 +362,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "creates a pull request" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).with({
+        expect(workflow.git_server).to receive(:create_pull_request).with({
           title: 'bingo',
           body: "\n",
           head: "#{user}:#{feature_branch}",
@@ -373,7 +372,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "notifies the user that the pull request was created" do
-        expect(GitReflow.git_server).to receive(:create_pull_request).and_return(existing_gh_pull_request)
+        expect(workflow.git_server).to receive(:create_pull_request).and_return(existing_gh_pull_request)
         expect{ subject }.to have_said "Successfully created pull request ##{existing_gh_pull_request.number}: #{existing_gh_pull_request.title}\nPull Request URL: #{existing_gh_pull_request.html_url}\n", :success
       end
 
@@ -382,7 +381,7 @@ describe GitReflow::Workflows::Core do
 
         it "retries creating a pull request" do
           call_count = 0
-          allow(GitReflow.git_server).to receive(:create_pull_request) do
+          allow(workflow.git_server).to receive(:create_pull_request) do
             call_count += 1
             (call_count <= 1) ? raise(github_error) : existing_gh_pull_request
           end
@@ -390,7 +389,7 @@ describe GitReflow::Workflows::Core do
         end
 
         it "reports failures even after retrying" do
-          allow(GitReflow.git_server).to receive(:create_pull_request).and_raise github_error
+          allow(workflow.git_server).to receive(:create_pull_request).and_raise github_error
           expect { subject }.to have_said "Github Error: #{github_error.to_s}", :error
         end
       end
@@ -404,7 +403,7 @@ describe GitReflow::Workflows::Core do
       end
 
       it "does not create a pull request" do
-        expect(GitReflow.git_server).to_not receive(:create_pull_request)
+        expect(workflow.git_server).to_not receive(:create_pull_request)
         subject
       end
 
@@ -422,13 +421,13 @@ describe GitReflow::Workflows::Core do
 
     before do
       allow(GitReflow).to receive(:git_server).and_return(GitReflow::GitServer)
-      allow(GitReflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
+      allow(workflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
       allow(GitReflow).to receive(:current_branch).and_return(feature_branch)
       allow(existing_gh_pull_request).to receive(:display_pull_request_summary)
     end
 
     context "with no existing pull request" do
-      before { allow(GitReflow.git_server).to receive(:find_open_pull_request).with({from: feature_branch, to: 'master'}).and_return(nil) }
+      before { allow(workflow.git_server).to receive(:find_open_pull_request).with({from: feature_branch, to: 'master'}).and_return(nil) }
       it     { expect{ subject }.to have_said "No pull request exists for #{feature_branch} -> master", :notice }
       it     { expect{ subject }.to have_said "Run 'git reflow review master' to start the review process", :notice }
     end
@@ -436,7 +435,7 @@ describe GitReflow::Workflows::Core do
     context "with an existing pull request" do
       let(:destination_branch) { 'master' }
       before do
-        allow(GitReflow.git_server).to receive(:find_open_pull_request).and_return(existing_gh_pull_request)
+        allow(workflow.git_server).to receive(:find_open_pull_request).and_return(existing_gh_pull_request)
       end
 
       it "displays a summary of the pull request" do
@@ -448,7 +447,7 @@ describe GitReflow::Workflows::Core do
         let(:destination_branch) { 'develop' }
 
         it "uses the custom destination branch to lookup the pull request" do
-          expect(GitReflow.git_server).to receive(:find_open_pull_request).with({from: feature_branch, to: destination_branch}).and_return(existing_gh_pull_request)
+          expect(workflow.git_server).to receive(:find_open_pull_request).with({from: feature_branch, to: destination_branch}).and_return(existing_gh_pull_request)
           subject
         end
       end
@@ -508,13 +507,13 @@ describe GitReflow::Workflows::Core do
     subject { workflow.stage }
 
     before do
-      allow(GitReflow).to receive(:current_branch).and_return(feature_branch)
-      allow(GitReflow::Config).to receive(:get).and_call_original
+      allow(workflow).to receive(:current_branch).and_return(feature_branch)
+      allow(workflow.git_config).to receive(:get).and_call_original
       allow(GitReflow::Workflows::Core).to receive(:deploy)
     end
 
     it "checks out and updates the staging branch" do
-      expect(GitReflow::Config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
+      expect(workflow.git_config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
       expect { subject }.to have_run_commands_in_order([
         "git checkout staging",
         "git pull origin staging",
@@ -525,9 +524,9 @@ describe GitReflow::Workflows::Core do
 
     context "merge is not successful" do
       before do
-        allow(GitReflow::Config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
-        allow(GitReflow).to receive(:run_command_with_label).and_call_original
-        expect(GitReflow).to receive(:run_command_with_label).with("git merge #{feature_branch}", with_system: true).and_return(false)
+        allow(workflow.git_config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
+        allow(workflow).to receive(:run_command_with_label).and_call_original
+        expect(workflow).to receive(:run_command_with_label).with("git merge #{feature_branch}", with_system: true).and_return(false)
       end
 
       it "notifies the user of unsuccessful merge" do
@@ -546,9 +545,9 @@ describe GitReflow::Workflows::Core do
 
     context "merge is successful" do
       before do
-        allow(GitReflow::Config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
-        allow(GitReflow).to receive(:run_command_with_label).and_call_original
-        expect(GitReflow).to receive(:run_command_with_label).with("git merge #{feature_branch}", with_system: true).and_return(true).and_call_original
+        allow(workflow.git_config).to receive(:get).with('reflow.staging-branch', local: true).and_return('staging')
+        allow(workflow).to receive(:run_command_with_label).and_call_original
+        expect(workflow).to receive(:run_command_with_label).with("git merge #{feature_branch}", with_system: true).and_return(true).and_call_original
       end
 
       specify { expect{ subject }.to have_run_command "git push origin staging" }
@@ -566,19 +565,19 @@ describe GitReflow::Workflows::Core do
 
     context "no staging branch has been setup" do
       before do
-        allow(GitReflow::Config).to receive(:get).with('reflow.staging-branch', local: true).and_return('')
+        allow(workflow.git_config).to receive(:get).with('reflow.staging-branch', local: true).and_return('')
         stub_command_line_inputs({
           "What's the name of your staging branch? (default: 'staging') " => "bobby"
           })
       end
 
       it "sets the reflow.staging-branch git config to 'staging'" do
-        expect(GitReflow::Config).to receive(:set).with("reflow.staging-branch", "bobby", local: true)
+        expect(workflow.git_config).to receive(:set).with("reflow.staging-branch", "bobby", local: true)
         subject
       end
 
       it "checks out and updates the staging branch" do
-        allow(GitReflow::Config).to receive(:set).with("reflow.staging-branch", "bobby", local: true)
+        allow(workflow.git_config).to receive(:set).with("reflow.staging-branch", "bobby", local: true)
         expect { subject }.to have_run_commands_in_order([
           "git checkout bobby",
           "git pull origin bobby",
@@ -620,18 +619,20 @@ describe GitReflow::Workflows::Core do
     before do
       allow(GitReflow).to receive(:git_server).and_return(GitReflow::GitServer)
       allow(GitReflow).to receive(:remote_user).and_return(user)
+      allow(workflow).to receive(:remote_user).and_return(user)
       allow(GitReflow).to receive(:current_branch).and_return(feature_branch)
-      allow(GitReflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
+      allow(workflow).to receive(:current_branch).and_return(feature_branch)
+      allow(workflow.git_server).to receive(:get_build_status).and_return(Struct.new(:state, :description, :url, :target_url).new)
     end
 
     context "pull request does not exist" do
-      before  { allow(GitReflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'master').and_return(nil) }
+      before  { allow(workflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'master').and_return(nil) }
       specify { expect{ subject }.to have_said "No pull request exists for #{user}:#{feature_branch}\nPlease submit your branch for review first with \`git reflow review\`", :deliver_halted }
     end
 
     context "pull request exists" do
       before do
-        allow(GitReflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'master').and_return(existing_gh_pull_request)
+        allow(workflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'master').and_return(existing_gh_pull_request)
         allow(GitReflow::Workflows::Core).to receive(:status)
       end
 
@@ -714,7 +715,7 @@ describe GitReflow::Workflows::Core do
       context "and using a custom base branch" do
         subject { workflow.deliver base: 'development' }
         before do
-          expect(GitReflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'development').and_return(existing_gh_pull_request)
+          expect(workflow.git_server).to receive(:find_open_pull_request).with( from: feature_branch, to: 'development').and_return(existing_gh_pull_request)
           allow(existing_gh_pull_request).to receive(:good_to_merge?).and_return(true)
         end
 
@@ -778,7 +779,7 @@ describe GitReflow::Workflows::Core do
     subject { workflow.refresh }
 
     it "updates the feature branch with default remote repo and base branch" do
-      expect(GitReflow).to receive(:update_feature_branch).with(remote: 'origin', base: 'master')
+      expect(workflow).to receive(:update_feature_branch).with(remote: 'origin', base: 'master')
       subject
     end
 
@@ -786,7 +787,17 @@ describe GitReflow::Workflows::Core do
       subject { workflow.refresh base: 'development' }
 
       it "updates the feature branch with default remote repo and base branch" do
-        expect(GitReflow).to receive(:update_feature_branch).with(remote: 'origin', base: 'development')
+        expect(workflow).to receive(:update_feature_branch).with(remote: 'origin', base: 'development')
+        subject
+      end
+    end
+
+    context "when a custom base branch is configured" do
+      before { allow(workflow.git_config).to receive(:get).with('reflow.base-branch').and_return('racecar') }
+      subject { workflow.refresh }
+
+      it "updates the feature branch with custom base branch" do
+        expect(workflow).to receive(:update_feature_branch).with(remote: 'origin', base: 'racecar')
         subject
       end
     end
@@ -795,7 +806,7 @@ describe GitReflow::Workflows::Core do
       subject { workflow.refresh remote: 'upstream' }
 
       it "updates the feature branch with default remote repo and base branch" do
-        expect(GitReflow).to receive(:update_feature_branch).with(remote: 'upstream', base: 'master')
+        expect(workflow).to receive(:update_feature_branch).with(remote: 'upstream', base: 'master')
         subject
       end
     end
@@ -804,7 +815,7 @@ describe GitReflow::Workflows::Core do
       subject { workflow.refresh remote: 'upstream', base: 'development' }
 
       it "updates the feature branch with default remote repo and base branch" do
-        expect(GitReflow).to receive(:update_feature_branch).with(remote: 'upstream', base: 'development')
+        expect(workflow).to receive(:update_feature_branch).with(remote: 'upstream', base: 'development')
         subject
       end
     end

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -153,6 +153,16 @@ describe GitReflow::Workflows::Core do
         "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
       ]
     end
+
+    it "starts from a different base branch when one is configured" do
+      allow(GitReflow::Config).to receive(:get).with("reflow.base-branch").and_return("sudo-master")
+      expect { CoreWorkflow.start feature_branch: feature_branch }.to have_run_commands_in_order [
+        "git checkout sudo-master",
+        "git pull origin sudo-master",
+        "git push origin sudo-master:refs/heads/#{feature_branch}",
+        "git checkout --track -b #{feature_branch} origin/#{feature_branch}"
+      ]
+    end
   end
 
   describe ".review" do


### PR DESCRIPTION
This adds checks for `reflow.base-branch` for all commands that use a base branch.  Keeps the default `master` in tact.
Fixes #202
