### PR TITLE
Update dependencies and trap INT signal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,8 +12,8 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     appraisal (2.2.0)
       bundler
       rake
@@ -37,17 +37,17 @@ GEM
       faraday (~> 0.8)
       hashie (~> 3.5, >= 3.5.2)
       oauth2 (~> 1.0)
-    hashdiff (0.3.8)
+    hashdiff (1.0.0)
     hashie (3.6.0)
     highline (2.0.2)
     httpclient (2.8.3)
-    jwt (2.1.0)
+    jwt (2.2.1)
     method_source (0.9.2)
     mini_portile2 (2.4.0)
     multi_json (1.13.1)
     multi_xml (0.6.0)
-    multipart-post (2.0.0)
-    nokogiri (1.10.2)
+    multipart-post (2.1.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)
@@ -61,10 +61,10 @@ GEM
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    public_suffix (3.0.3)
+    public_suffix (4.0.1)
     rack (2.0.7)
-    rake (12.3.2)
-    rdoc (6.1.1)
+    rake (12.3.3)
+    rdoc (6.2.0)
     reenhanced_bitbucket_api (0.3.2)
       faraday (~> 0.9.0)
       faraday_middleware (~> 0.9.0)
@@ -72,28 +72,28 @@ GEM
       multi_json (>= 1.7.5, < 2.0)
       nokogiri (>= 1.5.2)
       simple_oauth (>= 0.3.0)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.2)
     safe_yaml (1.0.5)
     simple_oauth (0.3.1)
     thor (0.20.3)
     thread_safe (0.3.6)
-    webmock (3.5.1)
+    webmock (3.7.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
-    wwtd (1.3.0)
+      hashdiff (>= 0.4.0, < 2.0.0)
+    wwtd (1.4.0)
 
 PLATFORMS
   ruby
@@ -105,9 +105,9 @@ DEPENDENCIES
   pry-byebug
   rake (~> 12.3)
   rdoc
-  rspec (~> 3.7.0)
+  rspec (~> 3.8)
   webmock
-  wwtd (= 1.3.0)
+  wwtd (= 1.4)
 
 BUNDLED WITH
    1.17.1

--- a/exe/git-reflow
+++ b/exe/git-reflow
@@ -9,6 +9,11 @@ if reflow_command.nil? || GitReflow.workflow.commands[reflow_command.to_sym].nil
 elsif ARGV.include? "--help"
   GitReflow.documentation_for_command(reflow_command)
 else
+  trap 'INT' do
+    GitReflow.say "Aborted.", :error
+    exit
+  end
+
   command_options = GitReflow.parse_command_options!(reflow_command)
   GitReflow.logger.debug "Running command `#{reflow_command}` with options: #{command_options.inspect}"
   GitReflow.public_send(reflow_command.to_sym, command_options)

--- a/git_reflow.gemspec
+++ b/git_reflow.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry-byebug')
   s.add_development_dependency('rake', "~> 12.3")
   s.add_development_dependency('rdoc')
-  s.add_development_dependency('rspec', "~> 3.7.0")
+  s.add_development_dependency('rspec', "~> 3.8")
   s.add_development_dependency('webmock')
-  s.add_development_dependency('wwtd', '1.3.0')
+  s.add_development_dependency('wwtd', '1.4')
 
   s.add_dependency('bundler', '>= 1.10.0')
   s.add_dependency('colorize', '>= 0.7.0')


### PR DESCRIPTION
This bumps several dependencies to the latest versions (mostly to resolve the
security issue with Nokogiri).  This also traps INT so that CTRL+C doesn't
display an ugly traceback, but instead displays an abort message.
