### PR TITLE
Fixes several issues related to git-reflow setup

### DIFF
--- a/spec/fixtures/authentication_failure.json
+++ b/spec/fixtures/authentication_failure.json
@@ -1,0 +1,3 @@
+{
+  "error" : "GET https://api.github.com/authorizations: 401 Bad credentials"
+}

--- a/spec/fixtures/users/user.json
+++ b/spec/fixtures/users/user.json
@@ -1,0 +1,32 @@
+{
+  "login": "reenhanced",
+  "id": 1,
+  "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+  "gravatar_id": "somehexcode",
+  "url": "https://api.github.com/users/reenhanced",
+  "name": "monalisa octocat",
+  "company": "GitHub",
+  "blog": "https://github.com/blog",
+  "location": "San Francisco",
+  "email": "octocat@github.com",
+  "hireable": false,
+  "bio": "There once was...",
+  "public_repos": 2,
+  "public_gists": 1,
+  "followers": 20,
+  "following": 0,
+  "html_url": "https://github.com/reenhanced",
+  "created_at": "2008-01-14T04:33:35Z",
+  "type": "User",
+  "total_private_repos": 100,
+  "owned_private_repos": 100,
+  "private_gists": 81,
+  "disk_usage": 10000,
+  "collaborators": 8,
+  "plan": {
+    "name": "Medium",
+    "space": 400,
+    "collaborators": 10,
+    "private_repos": 20
+  }
+}


### PR DESCRIPTION
There are times when a legacy user of git-reflow goes to re-run setup only to find themselves with blank configurations.  Since we are only validating presence of the github.oauth-token, there's an edge-case where the user could have _only_ the oauth-token configuration with missing user.  This causes some authentication failures and a bad user-experience.  This ensures that the user is asked for all required information, that the information is fully persisted to git-config, and gracefully handles authentication errors from GitHub in a more user-friendly way. Oh, and more tests :-)

Fixes #193
