### PR TITLE
Fix tests and bump Ruby versions in test workflows

### DIFF
--- a/.github/workflows/multi-ruby-tests.yml
+++ b/.github/workflows/multi-ruby-tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        ruby: ['2.6.6', '2.7.2', '3.0.0 ']
+        ruby: ['2.6.9', '2.7.5', '3.0.3 ', '3.1.1']
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/lib/git_reflow/git_helpers.rb
+++ b/lib/git_reflow/git_helpers.rb
@@ -14,6 +14,8 @@ module GitReflow
 
     def git_root_dir
       return @git_root_dir unless @git_root_dir.to_s.empty?
+      return @git_root_dir = Dir.pwd if Dir.exists?("#{Dir.pwd}/.git")
+
       @git_root_dir = run('git rev-parse --show-toplevel', loud: false).strip
     end
 

--- a/lib/git_reflow/workflow.rb
+++ b/lib/git_reflow/workflow.rb
@@ -78,13 +78,10 @@ module GitReflow
         GitReflow.git_server
       end
 
-      def logger
-        GitReflow.logger
-      end
       def logger(*args)
         return @logger if defined?(@logger)
 
-        @logger = GitReflow.logger(*args) || GitReflow::Logger.new(*args)
+        @logger = GitReflow.try(:logger, *args) || GitReflow::Logger.new(*args)
       rescue NoMethodError
         @logger = GitReflow::Logger.new(*args)
       end
@@ -121,10 +118,10 @@ module GitReflow
       # @param name [String] the name of the Workflow file to use as a basis
       def use(workflow_name)
         if workflows.key?(workflow_name)
-          GitReflow.logger.debug "Using Workflow: #{workflow_name}"
+          logger.debug "Using Workflow: #{workflow_name}"
           GitReflow::Workflows::Core.load_workflow(workflows[workflow_name])
         else
-          GitReflow.logger.error "Tried to use non-existent Workflow: #{workflow_name}"
+          logger.error "Tried to use non-existent Workflow: #{workflow_name}"
         end
       end
 

--- a/lib/git_reflow/workflow.rb
+++ b/lib/git_reflow/workflow.rb
@@ -1,3 +1,4 @@
+require 'git_reflow/logger'
 require 'git_reflow/sandbox'
 require 'git_reflow/git_helpers'
 require 'bundler/inline'
@@ -80,6 +81,13 @@ module GitReflow
       def logger
         GitReflow.logger
       end
+      def logger(*args)
+        return @logger if defined?(@logger)
+
+        @logger = GitReflow.logger(*args) || GitReflow::Logger.new(*args)
+      rescue NoMethodError
+        @logger = GitReflow::Logger.new(*args)
+      end
 
       # Checks for an installed gem, and if none is installed use bundler's
       # inline gemfile to install it.
@@ -157,7 +165,7 @@ module GitReflow
         self.commands[name] = params
         self.command_docs[name] = params
 
-        GitReflow.logger.debug "adding new command '#{name}' with #{defaults.inspect}"
+        logger.debug "adding new command '#{name}' with #{defaults.inspect}"
         self.define_singleton_method(name) do |args = {}|
           args_with_defaults = {}
           args.each do |name, value|
@@ -174,18 +182,18 @@ module GitReflow
             end
           end
 
-          GitReflow.logger.debug "callbacks: #{callbacks.inspect}"
+          logger.debug "callbacks: #{callbacks.inspect}"
           Array(callbacks[:before][name]).each do |block|
-            GitReflow.logger.debug "(before) callback running for `#{name}` command..."
+            logger.debug "(before) callback running for `#{name}` command..."
             argument_overrides = block.call(**args_with_defaults) || {}
             args_with_defaults.merge!(argument_overrides) if argument_overrides.is_a?(Hash)
           end
 
-          GitReflow.logger.info "Running command `#{name}` with args: #{args_with_defaults.inspect}..."
+          logger.info "Running command `#{name}` with args: #{args_with_defaults.inspect}..."
           block.call(**args_with_defaults)
 
           Array(callbacks[:after][name]).each do |block|
-            GitReflow.logger.debug "(after) callback running for `#{name}` command..."
+            logger.debug "(after) callback running for `#{name}` command..."
             block.call(**args_with_defaults)
           end
         end
@@ -203,9 +211,9 @@ module GitReflow
       def before(name, &block)
         name = name.to_sym
         if commands[name].nil?
-          GitReflow.logger.error "Attempted to register (before) callback for non-existing command: #{name}"
+          logger.error "Attempted to register (before) callback for non-existing command: #{name}"
         else
-          GitReflow.logger.debug "(before) callback registered for: #{name}"
+          logger.debug "(before) callback registered for: #{name}"
           callbacks[:before][name] ||= []
           callbacks[:before][name] << block
         end
@@ -223,9 +231,9 @@ module GitReflow
       def after(name, &block)
         name = name.to_sym
         if commands[name].nil?
-          GitReflow.logger.error "Attempted to register (after) callback for non-existing command: #{name}"
+          logger.error "Attempted to register (after) callback for non-existing command: #{name}"
         else
-          GitReflow.logger.debug "(after) callback registered for: #{name}"
+          logger.debug "(after) callback registered for: #{name}"
           callbacks[:after][name] ||= []
           callbacks[:after][name] << block
         end

--- a/lib/git_reflow/workflows/core.rb
+++ b/lib/git_reflow/workflows/core.rb
@@ -13,7 +13,7 @@ module GitReflow
       # @param workflow_path [String] the path of the Workflow file to eval
       def self.load_workflow(workflow_path)
         return unless workflow_path.length > 0 and File.exists?(workflow_path)
-        ::GitReflow.logger.debug "Using workflow: #{workflow_path}"
+        logger.debug "Using workflow: #{workflow_path}"
         self.load_raw_workflow(File.read(workflow_path))
       end
 
@@ -22,7 +22,7 @@ module GitReflow
       # @param workflow_string [String] the contents of a Workflow file to eval
       def self.load_raw_workflow(workflow_string)
         return if workflow_string.strip.empty?
-        ::GitReflow.logger.debug "Evaluating workflow..."
+        logger.debug "Evaluating workflow..."
         binding.eval(workflow_string)
       end
 

--- a/spec/lib/git_reflow/git_helpers_spec.rb
+++ b/spec/lib/git_reflow/git_helpers_spec.rb
@@ -30,7 +30,15 @@ describe GitReflow::GitHelpers do
 
   describe ".git_root_dir" do
     subject { Gitacular.git_root_dir }
-    it      { expect { subject }.to have_run_command_silently "git rev-parse --show-toplevel" }
+
+    before { Gitacular.instance_variable_set(:@git_root_dir, nil) }
+
+    it { expect(subject).to eq(Dir.pwd) }
+
+    context "when not in the root directory" do
+      before { allow(Dir).to receive(:pwd).and_return("/tmp/nope") }
+      it { expect { subject }.to have_run_command_silently "git rev-parse --show-toplevel" }
+    end
   end
 
   describe ".git_editor_command" do

--- a/spec/lib/git_reflow/workflows/core_spec.rb
+++ b/spec/lib/git_reflow/workflows/core_spec.rb
@@ -34,7 +34,6 @@ describe GitReflow::Workflows::Core do
   end
 
   describe ".load_raw_workflow(workflow_string)" do
-    before { allow(GitReflow::Workflows::Core).to receive(:load_workflow).and_call_original }
     it "evaluates the raw string in the context of the Core workflow" do
       workflow_content = <<~WORKFLOW_CONTENT
         command :dummy do
@@ -44,7 +43,7 @@ describe GitReflow::Workflows::Core do
       fake_binding = instance_double(Binding)
       expect(fake_binding).to receive(:eval).with(workflow_content)
       expect(described_class).to receive(:binding).and_return(fake_binding)
-      GitReflow::Workflows::Core.load_raw_workflow(workflow_content)
+      described_class.load_raw_workflow(workflow_content)
     end
   end
 

--- a/spec/lib/git_reflow_spec.rb
+++ b/spec/lib/git_reflow_spec.rb
@@ -41,6 +41,7 @@ describe GitReflow do
       it "calls the defined workflow methods instead of the default core" do
         workflow_path = File.join(File.expand_path("../../fixtures", __FILE__), "/awesome_workflow.rb")
         allow(GitReflow::Config).to receive(:get).with("reflow.workflow").and_return(workflow_path)
+        allow(GitReflow::Workflows::Core).to receive(:load_raw_workflow)
         expect(GitReflow::Workflows::Core).to receive(:load_raw_workflow).with(File.read(workflow_path)).and_call_original
 
         expect{ subject.start }.to have_said "Awesome."


### PR DESCRIPTION
I'm not entirely certain when this broke, but at some point an issue was introduced where the Workflow gets loaded before the top-level `GitReflow` module functions (namely `logger`).  This fixes the tests and bumps the Ruby versions we want to test against in the GitHub workflow.